### PR TITLE
Css mobile resp

### DIFF
--- a/projects/ds-ng/.storybook/preview.ts
+++ b/projects/ds-ng/.storybook/preview.ts
@@ -12,6 +12,7 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 import docJson from '../../../documentation.json';
 import { allModes } from './modes';
 import {
+  PREVIEW_TITLE,
   STORIES_TITLE,
   TITLE_OF_CONTROLS,
   TOC_OBJ,
@@ -53,6 +54,7 @@ const preview: Preview = {
         return [
           Title({}),
           Description({}),
+          Heading({ children: PREVIEW_TITLE }),
           Primary({}),
           Heading({ children: TITLE_OF_CONTROLS }),
           Controls({}),

--- a/projects/ds-ng/src/DocComponents/GeneralTemplate.mdx
+++ b/projects/ds-ng/src/DocComponents/GeneralTemplate.mdx
@@ -7,7 +7,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 
-import { TitleOfControls } from './Utils.mdx';
+import { PreviewTitle, TitleOfControls } from './Utils.mdx';
 import { STORIES_TITLE } from '../lib/utils/doc/utils';
 
 export const GeneralTemplate = ({
@@ -21,6 +21,7 @@ export const GeneralTemplate = ({
     {(children && <Description of={children}>{children}</Description>) || (
       <Description />
     )}
+    <PreviewTitle />
     {(children && <Primary of={children} />) || <Primary />}
     {showControls && <TitleOfControls />}
     {(children && showControls && <Controls of={children.Default} />) ||

--- a/projects/ds-ng/src/DocComponents/Utils.mdx
+++ b/projects/ds-ng/src/DocComponents/Utils.mdx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Heading } from '@storybook/addon-docs/blocks';
-import { TITLE_OF_CONTROLS } from '../lib/utils/doc/utils';
+import { PREVIEW_TITLE, TITLE_OF_CONTROLS } from '../lib/utils/doc/utils';
 
 export const TitleOfControls = () => <Heading>{TITLE_OF_CONTROLS}</Heading>;
+export const PreviewTitle = () => <Heading>{PREVIEW_TITLE}</Heading>;

--- a/projects/ds-ng/src/assets/styles/base/_mixins.scss
+++ b/projects/ds-ng/src/assets/styles/base/_mixins.scss
@@ -2,16 +2,35 @@
 @use 'sass:string';
 @use 'fonts' as fonts;
 @use 'rem' as rem;
+@use '../base/vars' as vars;
 
 // Media query
-@mixin media-query($breakpoint, $condition) {
-  $breakpoint-value: if(
+@mixin media-query($breakpoint, $condition, $isPixel: true) {
+  $breakpoint_value: if(
     meta.type-of($breakpoint) == number,
     $breakpoint,
     string.slice($breakpoint, 1, -2)
   );
-  @media (#{$condition}-width: #{$breakpoint-value}px) {
-    @content;
+  @if $isPixel == true {
+    @media (#{$condition}-width: #{$breakpoint_value}px) {
+      @content;
+    }
+  } @else {
+    @media (#{$condition}-width: #{$breakpoint_value}) {
+      @content;
+    }
+  }
+}
+
+@mixin media-range-query($breakpoint_min, $breakpoint_max, $isPixel: true) {
+  @if $isPixel == true {
+    @media (width >= #{$breakpoint_min}px) and (width <= #{$breakpoint_max}px) {
+      @content;
+    }
+  } @else {
+    @media (width >= $breakpoint_min) and (width <= $breakpoint_max) {
+      @content;
+    }
   }
 }
 
@@ -26,17 +45,17 @@
 }
 
 // Reset Element
-@mixin resetElement() {
+@mixin reset-element() {
   box-sizing: border-box;
   line-height: 1.5;
 
   &:focus {
-    @include focusElement();
+    @include focus-element();
   }
 }
 
 // Focus for button and input
-@mixin focusElement($inset: outset) {
+@mixin focus-element($inset: outset) {
   outline: 0;
 }
 
@@ -91,7 +110,7 @@
     padding: rem.rem_calc(11 15);
     transition: none;
 
-    @include checkForMobile(false) {
+    @include check-for-mobile(false) {
       padding: rem.rem_calc(7 39);
     }
 
@@ -100,7 +119,7 @@
       border-width: rem.rem_calc(2);
       padding: rem.rem_calc(10 14);
 
-      @include checkForMobile(false) {
+      @include check-for-mobile(false) {
         padding: rem.rem_calc(6 38);
       }
     }
@@ -115,7 +134,7 @@
       color: var(--general_contrasts-5);
       background-color: var(--general_contrasts-100);
 
-      @include checkForMobile(false) {
+      @include check-for-mobile(false) {
         padding: rem.rem_calc(6 38);
       }
 
@@ -134,7 +153,7 @@
     color: var(--red-primary);
     padding: rem.rem_calc(11 15);
 
-    @include checkForMobile(false) {
+    @include check-for-mobile(false) {
       padding: rem.rem_calc(7 39);
     }
 
@@ -143,7 +162,7 @@
       border-width: rem.rem_calc(2);
       padding: rem.rem_calc(10 14);
 
-      @include checkForMobile(false) {
+      @include check-for-mobile(false) {
         padding: rem.rem_calc(6 38);
       }
     }
@@ -155,7 +174,7 @@
       padding: rem.rem_calc(10 14);
       border-width: rem.rem_calc(2);
 
-      @include checkForMobile(false) {
+      @include check-for-mobile(false) {
         padding: rem.rem_calc(6 38);
       }
 
@@ -179,7 +198,7 @@
   }
 }
 
-@mixin fabContent() {
+@mixin fab-content() {
   align-items: center;
   border: 0;
   @include fonts.font(4, regular);
@@ -190,7 +209,7 @@
   padding: var(--bmb-spacing-s) var(--bmb-spacing-m);
 }
 
-@mixin fabSize($size: small, $type: normal) {
+@mixin fab-size($size: small, $type: normal) {
   @if $size == small and $type == normal {
     border-radius: rem.rem_calc(50);
     height: rem.rem_calc(40);
@@ -216,8 +235,8 @@
   }
 }
 
-@mixin fabInput() {
-  @include fabContent();
+@mixin fab-input() {
+  @include fab-content();
   bottom: rem.rem_calc(10);
   position: fixed;
   right: rem.rem_calc(10);
@@ -254,7 +273,7 @@
   }
 }
 
-@mixin shadow_mark($color_name, $opacity: 0.1) {
+@mixin shadow-mark($color_name, $opacity: 0.1) {
   content: '';
   height: rem.rem_calc(42);
   width: rem.rem_calc(42);
@@ -270,11 +289,11 @@
   left: rem.rem_calc(-14);
 }
 
-@mixin error_input() {
+@mixin error-input() {
   border-color: var(--input-error);
 }
 
-@mixin input_checked($height, $width) {
+@mixin input-checked($height, $width) {
   display: block;
   position: relative;
   margin: rem.rem_calc(2) auto 0;
@@ -282,15 +301,15 @@
   width: rem.rem_calc($width);
 }
 
-@mixin input_shadow($color_name) {
+@mixin input-shadow($color_name) {
   &:hover {
     &::before {
-      @include shadow_mark($color_name);
+      @include shadow-mark($color_name);
     }
   }
 }
 
-@mixin input_mark($color_name, $border_radius) {
+@mixin input-mark($color_name, $border_radius) {
   cursor: pointer;
   display: flex;
   position: relative;
@@ -308,16 +327,16 @@
   }
 
   &-error {
-    @include error_input();
+    @include error-input();
   }
 }
 
-@mixin input_placeholder() {
+@mixin input-placeholder() {
   @include fonts.font(4, regular);
   color: var(--general_contrasts-50);
 }
 
-@mixin normal_input() {
+@mixin normal-input() {
   box-sizing: border-box;
   border: rem.rem_calc(1) solid var(--general_contrasts-50);
   border-radius: rem.rem_calc(8);
@@ -327,7 +346,7 @@
   transition: all 0.3s ease;
 }
 
-@mixin normal_input_focus() {
+@mixin normal-input-focus() {
   &:focus,
   &:focus-visible,
   &-focus {
@@ -346,7 +365,7 @@
   }
 }
 
-@mixin truncated_string($max-block-size, $line-clamp) {
+@mixin truncated-string($max-block-size, $line-clamp) {
   display: -webkit-box;
   max-block-size: rem.rem_calc($max-block-size);
   -webkit-box-orient: vertical;
@@ -357,13 +376,13 @@
   text-overflow: ellipsis;
 }
 
-@mixin truncated_string_line() {
+@mixin truncated-string-line() {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-@mixin dropdown_menu_left($max-width) {
+@mixin dropdown-menu-left($max-width) {
   .bmb_dropdown-content-modal {
     right: 0;
     left: inherit;
@@ -372,41 +391,51 @@
   }
 }
 
-@mixin helper_text() {
+@mixin helper-text() {
   @include fonts.font(4, regular);
   margin: 0;
 }
 
-@mixin normal_helper_text() {
-  @include helper_text();
+@mixin normal-helper-text() {
+  @include helper-text();
   color: var(--general_contrasts-input-outline);
 }
 
-@mixin error_helper_text() {
-  @include helper_text();
+@mixin error-helper-text() {
+  @include helper-text();
   color: var(--input-error);
 }
 
-@mixin checkForMobile($condition: true) {
+@mixin media-web-templates() {
+  @include media-range-query(
+    vars.$breakpoint_min_web,
+    rem.rem_calc(1800),
+    false
+  ) {
+    @content;
+  }
+}
+
+@mixin check-for-mobile($condition: true) {
   @if $condition == true {
-    @include media-query(1000, 'max') {
+    @include media-query(vars.$breakpoint_max_mobile, 'max', false) {
       @content;
     }
   } @else {
-    @include media-query(1001, 'min') {
+    @include media-query(vars.$breakpoint_min_web, 'min', false) {
       @content;
     }
   }
 }
 
-@mixin hiddenForMobile() {
-  @include checkForMobile() {
+@mixin hidden-for-mobile() {
+  @include check-for-mobile() {
     display: none;
   }
 }
 
-@mixin hiddenForNoMobile() {
-  @include checkForMobile(false) {
+@mixin hidden-for-no-mobile() {
+  @include check-for-mobile(false) {
     display: none;
   }
 }

--- a/projects/ds-ng/src/assets/styles/base/_mixins.scss
+++ b/projects/ds-ng/src/assets/styles/base/_mixins.scss
@@ -5,13 +5,13 @@
 @use '../base/vars' as vars;
 
 // Media query
-@mixin media-query($breakpoint, $condition, $isPixel: true) {
+@mixin media-query($breakpoint, $condition, $is_px: true) {
   $breakpoint_value: if(
     meta.type-of($breakpoint) == number,
     $breakpoint,
     string.slice($breakpoint, 1, -2)
   );
-  @if $isPixel == true {
+  @if $is_px == true {
     @media (#{$condition}-width: #{$breakpoint_value}px) {
       @content;
     }
@@ -22,8 +22,8 @@
   }
 }
 
-@mixin media-range-query($breakpoint_min, $breakpoint_max, $isPixel: true) {
-  @if $isPixel == true {
+@mixin media-range-query($breakpoint_min, $breakpoint_max, $is_px: true) {
+  @if $is_px == true {
     @media (width >= #{$breakpoint_min}px) and (width <= #{$breakpoint_max}px) {
       @content;
     }
@@ -41,6 +41,22 @@
   */
   @container (#{$condition}-width: #{$breakpoint}px) {
     @content;
+  }
+}
+
+@mixin container-range-query($breakpoint_min, $breakpoint_max, $is_px: true) {
+  /*
+  Add this property to parent style:
+    container-type: inline-size;
+  */
+  @if $is_px == true {
+    @container (width >= #{$breakpoint_min}px) and (width <= #{$breakpoint_max}px) {
+      @content;
+    }
+  } @else {
+    @container (width >= $breakpoint_min) and (width <= $breakpoint_max) {
+      @content;
+    }
   }
 }
 

--- a/projects/ds-ng/src/assets/styles/base/_vars.scss
+++ b/projects/ds-ng/src/assets/styles/base/_vars.scss
@@ -1,0 +1,2 @@
+$breakpoint_max_mobile: 62.5rem; //1000px
+$breakpoint_min_web: 62.563rem; //1001px

--- a/projects/ds-ng/src/assets/styles/components/_button-group.scss
+++ b/projects/ds-ng/src/assets/styles/components/_button-group.scss
@@ -1,7 +1,7 @@
 @use '../base/mixins' as mixins;
 @use '../base/rem' as rem;
 
-@mixin first_child($padding) {
+@mixin first-child($padding) {
   & {
     border-width: rem.rem_calc(1 1 1 0);
     padding: $padding;
@@ -36,7 +36,7 @@
   }
 }
 
-@mixin secondary_outlined() {
+@mixin secondary-outlined() {
   & {
     box-sizing: border-box;
   }
@@ -69,36 +69,36 @@
     &.bmb_button-group-primary {
       > * {
         @include mixins.button(primary);
-        @include first_child(rem.rem_calc(8));
+        @include first-child(rem.rem_calc(8));
       }
     }
 
     &.bmb_button-group-secondary-filled {
       > * {
         @include mixins.button(secondary-filled);
-        @include first_child(rem.rem_calc(8));
+        @include first-child(rem.rem_calc(8));
       }
     }
 
     &.bmb_button-group-secondary-outlined {
       > * {
         @include mixins.button(secondary-outlined);
-        @include first_child(rem.rem_calc(8));
-        @include secondary_outlined();
+        @include first-child(rem.rem_calc(8));
+        @include secondary-outlined();
       }
     }
 
     &.bmb_button-group-destructive {
       > * {
         @include mixins.button(destructive);
-        @include first_child(rem.rem_calc(8));
+        @include first-child(rem.rem_calc(8));
         @include destructive();
       }
     }
 
     &.bmb_button-group-transparent {
       > * {
-        @include first_child(rem.rem_calc(8));
+        @include first-child(rem.rem_calc(8));
       }
     }
   }
@@ -107,29 +107,29 @@
     &.bmb_button-group-primary {
       > * {
         @include mixins.button(primary);
-        @include first_child(rem.rem_calc(8 16));
+        @include first-child(rem.rem_calc(8 16));
       }
     }
 
     &.bmb_button-group-secondary-filled {
       > * {
         @include mixins.button(secondary-filled);
-        @include first_child(rem.rem_calc(8 16));
+        @include first-child(rem.rem_calc(8 16));
       }
     }
 
     &.bmb_button-group-secondary-outlined {
       > * {
         @include mixins.button(secondary-outlined);
-        @include first_child(rem.rem_calc(8 16));
-        @include secondary_outlined();
+        @include first-child(rem.rem_calc(8 16));
+        @include secondary-outlined();
       }
     }
 
     &.bmb_button-group-destructive {
       > * {
         @include mixins.button(destructive);
-        @include first_child(rem.rem_calc(8 16));
+        @include first-child(rem.rem_calc(8 16));
         @include destructive();
       }
     }
@@ -137,7 +137,7 @@
     &.bmb_button-group-transparent {
       > * {
         @include mixins.button(transparent);
-        @include first_child(rem.rem_calc(8 16));
+        @include first-child(rem.rem_calc(8 16));
       }
     }
   }

--- a/projects/ds-ng/src/assets/styles/components/_buttons.scss
+++ b/projects/ds-ng/src/assets/styles/components/_buttons.scss
@@ -16,7 +16,7 @@
   transition: all 0.1s linear;
   transition-property: color, text-shadow, box-shadow, background-color;
 
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     padding: rem.rem_calc(8 40);
   }
 
@@ -33,7 +33,7 @@
 
   &:focus,
   &:focus:hover {
-    @include mixins.focusElement();
+    @include mixins.focus-element();
   }
 
   &[size='micro'] {

--- a/projects/ds-ng/src/assets/styles/components/_col-sys.scss
+++ b/projects/ds-ng/src/assets/styles/components/_col-sys.scss
@@ -34,11 +34,32 @@ $alignItemsOptions: (
   'stretch': stretch,
 );
 
-@mixin margin_side($side, $i, $size) {
+@mixin margin-side($side, $i, $size) {
   margin-#{$side}: calc(
     #{math.percentage(math.div($i, $size))} + var(--bmb-gap) - (var(--bmb-gap) /
           $size * #{$size - $i})
   );
+}
+
+@mixin one-column() {
+  &:not(.bmb_col-sm-1):not(.bmb_col-sm-2):not(.bmb_col-sm-3):not(
+      .bmb_col-sm-4
+    ) {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+
+@mixin columns($index) {
+  flex: 0 0
+    calc(
+      #{math.percentage(math.div($index, 12))} - (var(--bmb-gap) / 12 * #{12 -
+            $index})
+    ) !important;
+  max-width: calc(
+    #{math.percentage(math.div($index, 12))} - (var(--bmb-gap) / 12 * #{12 -
+          $index})
+  ) !important;
 }
 
 .bmb_layout {
@@ -69,24 +90,12 @@ $alignItemsOptions: (
   .bmb_col-lg-#{$i} {
     overflow: visible;
 
-    @include mixins.checkForMobile() {
-      &:not(.bmb_col-sm-1):not(.bmb_col-sm-2):not(.bmb_col-sm-3):not(
-          .bmb_col-sm-4
-        ) {
-        flex: 0 0 100%;
-        max-width: 100%;
-      }
+    @include mixins.check-for-mobile() {
+      @include one-column();
     }
 
-    @include mixins.checkForMobile(false) {
-      flex: 0 0
-        calc(
-          #{math.percentage(math.div($i, 12))} - (var(--bmb-gap) / 12 * #{12 -
-                $i})
-        ) !important;
-      max-width: calc(
-        #{math.percentage(math.div($i, 12))} - (var(--bmb-gap) / 12 * #{12 - $i})
-      ) !important;
+    @include mixins.check-for-mobile(false) {
+      @include columns($i);
     }
   }
 }
@@ -95,15 +104,7 @@ $alignItemsOptions: (
   @each $margin, $size in $marginSizes {
     @for $i from 1 through $size {
       .bmb_space-#{$margin}-#{$side}-#{$i} {
-        @if $margin == 'sm' {
-          @include mixins.checkForMobile() {
-            @include margin_side($side, $i, $size);
-          }
-        } @else {
-          @include mixins.checkForMobile(false) {
-            @include margin_side($side, $i, $size);
-          }
-        }
+        @include margin-side($side, $i, $size);
       }
     }
   }

--- a/projects/ds-ng/src/assets/styles/components/_organism.scss
+++ b/projects/ds-ng/src/assets/styles/components/_organism.scss
@@ -7,11 +7,11 @@
   height: 100dvh;
 
   &-main {
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       padding: rem.rem_calc(48 152);
     }
 
-    @include mixins.checkForMobile() {
+    @include mixins.check-for-mobile() {
       padding: rem.rem_calc(8);
     }
   }
@@ -21,12 +21,12 @@
   }
 
   .bmb_home-card-wrapper {
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       //64px (top bar height) + 48px (main padding-top) =  102px
       height: calc(100% - rem.rem_calc(102));
     }
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       //64px (top bar height) + 8px (main padding-top) =  102px
       height: calc(100% - rem.rem_calc(72));
     }

--- a/projects/ds-ng/src/assets/styles/components/_templates.scss
+++ b/projects/ds-ng/src/assets/styles/components/_templates.scss
@@ -1,4 +1,5 @@
 @use '../base/mixins' as mixins;
+@use '../base/vars' as vars;
 @use '../base/rem' as rem;
 
 .bmb_template-header {
@@ -8,7 +9,7 @@
   padding: rem.rem_calc(24) rem.rem_calc(24) rem.rem_calc(24) rem.rem_calc(100);
   width: 100%;
 
-  @media (max-width: 1000px) {
+  @include mixins.check-for-mobile() {
     padding: rem.rem_calc(24) rem.rem_calc(24) rem.rem_calc(24) rem.rem_calc(40);
   }
 }
@@ -45,7 +46,12 @@
       margin: var(--bmb-spacing-xxs);
       padding-left: rem.rem_calc(30);
     }
-    @media (width <= 1000px) and (width >= 630px) {
+
+    @include mixins.media-range-query(
+      rem.rem_calc(631),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       padding-left: rem.rem_calc(40);
     }
   }
@@ -101,7 +107,12 @@
       height: max-content;
       margin: var(--bmb-spacing-xxs);
     }
-    @media (width <= 1000px) and (width >= 630px) {
+
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(15);
     }
   }
@@ -158,7 +169,11 @@
       margin: var(--bmb-spacing-xxs);
     }
 
-    @media (width <= 1000px) and (width >= 630px) {
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(20);
     }
   }
@@ -211,7 +226,11 @@
       margin: var(--bmb-spacing-xxs);
     }
 
-    @media (width <= 1000px) and (width >= 630px) {
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(20);
     }
   }
@@ -253,7 +272,7 @@
       height: max-content;
       margin: var(--bmb-spacing-xxs);
     }
-    @media (max-width: 1000px) {
+    @include mixins.check-for-mobile() {
       padding-left: rem.rem_calc(20);
     }
   }
@@ -309,7 +328,12 @@
       height: max-content;
       margin: var(--bmb-spacing-xxs);
     }
-    @media (width <= 1000px) and (width >= 630px) {
+
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(15);
     }
   }
@@ -367,7 +391,12 @@
       height: max-content;
       margin: var(--bmb-spacing-xxs);
     }
-    @media (width <= 1000px) and (width >= 630px) {
+
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(15);
     }
   }
@@ -386,7 +415,11 @@
       margin: var(--bmb-spacing-xxs);
     }
 
-    @media (width <= 1000px) and (width >= 630px) {
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(15);
     }
   }
@@ -432,7 +465,11 @@
       margin: var(--bmb-spacing-xxs);
     }
 
-    @media (width <= 1000px) and (width >= 630px) {
+    @include mixins.media-range-query(
+      rem.rem_calc(630),
+      vars.$breakpoint_max_mobile,
+      false
+    ) {
       margin-left: rem.rem_calc(20);
     }
   }
@@ -484,7 +521,7 @@
     flex: 1;
     padding: rem.rem_calc(16);
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       padding: rem.rem_calc(96 140);
     }
   }
@@ -514,7 +551,7 @@
 .bmb_template-accordion {
   height: calc(100% - rem.rem_calc(32));
 
-  @include mixins.checkForMobile(false) {
+  @include mixins.check-for-mobile(false) {
     height: calc(100% - rem.rem_calc(140));
   }
 
@@ -590,7 +627,7 @@
   flex-flow: column nowrap;
   margin: rem.rem_calc(24 24 24 100);
 
-  @media (max-width: 1000px) {
+  @include mixins.check-for-mobile() {
     margin-left: rem.rem_calc(40);
   }
 
@@ -707,7 +744,7 @@
 .bmb_template-margin-for-sidebar {
   margin: rem.rem_calc(16);
 
-  @media (min-width: 1000px) {
+  @include mixins.check-for-mobile(false) {
     margin-left: rem.rem_calc(100);
   }
 }

--- a/projects/ds-ng/src/assets/styles/main.scss
+++ b/projects/ds-ng/src/assets/styles/main.scss
@@ -9,6 +9,7 @@
 
 @use 'base/css-vars';
 @use 'base/rem' as rem;
+@use 'base/vars' as vars;
 
 // Import fonts
 @use 'base/fonts' as fonts;

--- a/projects/ds-ng/src/assets/styles/tokens/theme.scss
+++ b/projects/ds-ng/src/assets/styles/tokens/theme.scss
@@ -529,7 +529,7 @@ img {
 }
 
 //Storybook alert blockquote
-@mixin markdown_alert_text() {
+@mixin markdown-alert-text() {
   border-radius: 0.5rem 0.5rem 0.5rem 0;
   padding-top: 0.25rem !important;
   padding-bottom: 0.5rem !important;
@@ -546,30 +546,53 @@ img {
 
 .markdown-alert {
   &-note {
-    @include markdown_alert_text();
+    @include markdown-alert-text();
     background-color: rgba(var(--color-blue-light), 0.15);
   }
 
   &-callout {
-    @include markdown_alert_text();
+    @include markdown-alert-text();
     background-color: rgba(var(--color-mitec-green), 0.15);
   }
 
   &-warning {
-    @include markdown_alert_text();
+    @include markdown-alert-text();
     background-color: rgba(var(--color-red-light), 0.15);
   }
 }
 //Storybook alert blockquote - end
 
+//Table of contents
+.css-q7khkg {
+  width: fit-content !important;
+  padding-right: 0.25rem;
+  z-index: 999;
+
+  .toc-list-item {
+    margin-left: 0.75rem !important;
+  }
+}
+
 //Documentation width
-.css-x28zkw:has(.bmb_top-bar) {
-  max-width: 1444px !important;
+.css-x28zkw {
+  max-width: 63.125rem !important;
+
+  &:has(.bmb_top-bar) {
+    max-width: 90.25rem !important;
+  }
+}
+
+//Controls width
+.docblock-argstable,
+.css-v2ifgj.css-v2ifgj {
+  width: auto;
 }
 
 // Expanded preview
 .css-1cvjpgl:has(.bmb_top-bar),
-.css-1cvjpgl:has(.bmb_sidebar) {
+.css-1cvjpgl:has(.bmb_sidebar),
+.sb-show-main.sb-main-padded:has(.bmb_top-bar),
+.sb-show-main.sb-main-padded:has(.bmb_sidebar) {
   padding: 0 !important;
 
   .innerZoomElementWrapper {

--- a/projects/ds-ng/src/lib/components/bmb-alert-center/bmb-alert-center-list/bmb-alert-center-list.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-alert-center/bmb-alert-center-list/bmb-alert-center-list.component.scss
@@ -1,7 +1,7 @@
 @use '../../../../assets/styles/base/fonts' as fonts;
 @use '../../../../assets/styles/base/rem' as rem;
 
-@mixin fontTime() {
+@mixin font-time() {
   @include fonts.font(3, regular);
   color: var(--general_contrasts-50);
   font-weight: 400;
@@ -58,12 +58,12 @@
     }
 
     &-date {
-      @include fontTime();
+      @include font-time();
       grid-area: date;
     }
 
     &-time {
-      @include fontTime();
+      @include font-time();
       grid-area: time;
       margin-top: rem.rem_calc(6);
       text-transform: lowercase;

--- a/projects/ds-ng/src/lib/components/bmb-alert-center/bmb-alert-center.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-alert-center/bmb-alert-center.component.scss
@@ -14,7 +14,7 @@
   &-main {
     position: relative;
 
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       border-right: rem.rem_calc(1) solid var(--general_contrasts-15);
     }
 

--- a/projects/ds-ng/src/lib/components/bmb-balance-overview/bmb-balance-overview.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-balance-overview/bmb-balance-overview.component.scss
@@ -6,7 +6,7 @@
   &-container {
     padding-bottom: rem.rem_calc(10);
 
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       display: flex;
       gap: var(--bmb-spacing-xl);
     }
@@ -15,7 +15,7 @@
   &-circle-container {
     padding-bottom: rem.rem_calc(24);
 
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       max-width: rem.rem_calc(500);
     }
   }
@@ -26,7 +26,7 @@
     width: 100%;
     gap: var(--bmb-spacing-m);
 
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       flex-direction: column;
       justify-content: flex-start;
     }

--- a/projects/ds-ng/src/lib/components/bmb-calendar/bmb-calendar.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-calendar/bmb-calendar.component.scss
@@ -49,7 +49,7 @@
     top: 0;
     z-index: 1;
     background-color: var(--containers-main);
-    @include mixins.media-query(999, 'max') {
+    @include mixins.check-for-mobile() {
       display: none;
     }
 

--- a/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-header/bmb-calendar-header.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-header/bmb-calendar-header.component.scss
@@ -4,7 +4,7 @@
 
 .bmb_calendar-header {
   padding-bottom: rem.rem_calc(16);
-  @include mixins.media-query(999, 'max') {
+  @include mixins.check-for-mobile() {
     display: none;
   }
 

--- a/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-mobile/bmb-calendar-template-mobile.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-mobile/bmb-calendar-template-mobile.component.scss
@@ -2,7 +2,7 @@
 @use '../../../../../assets/styles/base/fonts' as fonts;
 @use '../../../../../assets/styles/base/mixins' as mixins;
 
-@mixin buttonNavDark() {
+@mixin button-nav-dark() {
   color: RGBA(var(--color-charade-200), 0.5);
 
   &:hover:not(:disabled):not(.bmb-disabled),

--- a/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-month/bmb-calendar-template-month.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-month/bmb-calendar-template-month.component.scss
@@ -37,7 +37,7 @@
 
     &-name {
       text-transform: capitalize;
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         display: none;
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-select/bmb-calendar-template-select.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-calendar/common/bmb-calendar-template-select/bmb-calendar-template-select.component.scss
@@ -1,6 +1,6 @@
 @use '../../../../../assets/styles/base/rem' as rem;
 
-@mixin buttonReset() {
+@mixin button-reset() {
   background-color: transparent;
 
   &:hover:not(:disabled):not(.bmb-disabled),
@@ -11,7 +11,7 @@
   }
 }
 
-@mixin buttonResetDark() {
+@mixin button-reset-dark() {
   color: RGBA(var(--color-charade-50));
 
   &:hover:not(:disabled):not(.bmb-disabled),
@@ -33,7 +33,7 @@
   button {
     width: 100%;
     text-transform: capitalize;
-    @include buttonReset();
+    @include button-reset();
   }
 
   &-menu {
@@ -76,7 +76,7 @@
 .storybook-dark-theme {
   .bmb-calendar-template-select {
     button {
-      @include buttonResetDark();
+      @include button-reset-dark();
 
       bmb-icon {
         color: RGBA(var(--color-charade-50));

--- a/projects/ds-ng/src/lib/components/bmb-card-button/bmb-card-button.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-card-button/bmb-card-button.component.scss
@@ -7,7 +7,7 @@
   box-shadow: var(--bmb-box-shadow-3);
 }
 
-@mixin small_selected() {
+@mixin small-selected() {
   .bmb_card_button-small-back {
     background-color: var(--menu_select-surface-activated);
   }
@@ -130,7 +130,7 @@
   }
 
   &-menu {
-    @include mixins.dropdown_menu_left(250);
+    @include mixins.dropdown-menu-left(250);
   }
 
   &-template {
@@ -168,7 +168,7 @@
     @include fonts.font(3, regular);
     color: var(--general_contrasts-50);
     padding: rem.rem_calc(8 0);
-    @include mixins.truncated_string(64, 3);
+    @include mixins.truncated-string(64, 3);
 
     .bmb_text-link .bmb_check-external-link-button-element {
       line-height: 1;
@@ -188,7 +188,7 @@
       margin-top: rem.rem_calc(10);
       max-width: 100%;
       padding: rem.rem_calc(0 16);
-      @include mixins.truncated_string(40, 2);
+      @include mixins.truncated-string(40, 2);
     }
 
     &:hover:not(:disabled) {
@@ -212,7 +212,7 @@
     justify-content: flex-start;
 
     &:active:not(:disabled) {
-      @include small_selected();
+      @include small-selected();
     }
 
     &:hover {
@@ -223,7 +223,7 @@
 
     &-flipped {
       transform: rotateY(180deg);
-      @include small_selected();
+      @include small-selected();
     }
 
     &-front,
@@ -273,7 +273,7 @@
       color: var(--general_contrasts-75);
       @include fonts.font(4, bold);
       text-align: center;
-      @include mixins.truncated_string(40, 2);
+      @include mixins.truncated-string(40, 2);
     }
 
     &-text {

--- a/projects/ds-ng/src/lib/components/bmb-chat-bar/bmb-chat-bar.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-chat-bar/bmb-chat-bar.component.scss
@@ -1,6 +1,7 @@
 @use '../../../assets/styles/base/rem' as rem;
 @use '../../../assets/styles/base/fonts' as fonts;
 @use '../../../assets/styles/base/mixins' as mixins;
+@use '../../../assets/styles/base/vars' as vars;
 
 .bmb_chat-bar {
   position: relative;
@@ -96,7 +97,7 @@
     position: relative;
     padding: rem.rem_calc(10 16);
 
-    @include mixins.media-query(1001, 'min') {
+    @include mixins.check-for-mobile(false) {
       padding: rem.rem_calc(16);
     }
   }
@@ -192,7 +193,7 @@
       max-height: rem.rem_calc(200);
       overflow: auto;
 
-      @media (min-width: 1001px) {
+      @include mixins.check-for-mobile(false) {
         flex-direction: row;
       }
     }
@@ -206,7 +207,7 @@
       padding: rem.rem_calc(16);
       width: 100%;
 
-      @media (min-width: 1001px) {
+      @include mixins.check-for-mobile(false) {
         width: max-content;
       }
 
@@ -216,7 +217,7 @@
         white-space: nowrap;
         flex: 1;
 
-        @media (min-width: 1001px) {
+        @include mixins.check-for-mobile(false) {
           max-width: rem.rem_calc(200);
         }
       }

--- a/projects/ds-ng/src/lib/components/bmb-checkbox/bmb-checkbox.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-checkbox/bmb-checkbox.component.scss
@@ -2,11 +2,11 @@
 @use '../../../assets/styles/base/mixins' as mixins;
 @use '../../../assets/styles/base/rem' as rem;
 
-@mixin focus_mark($color) {
+@mixin focus-mark($color) {
   &:focus,
   &:focus-visible {
     & + .bmb_checkbox-mark::before {
-      @include mixins.shadow_mark($color);
+      @include mixins.shadow-mark($color);
     }
   }
 }
@@ -19,16 +19,16 @@
     position: absolute;
 
     &:is(:checked) {
-      @include focus_mark(var(--buttons-active-switch));
+      @include focus-mark(var(--buttons-active-switch));
 
       & + .bmb_checkbox-mark {
         background-color: var(--buttons-active-switch);
         border-color: var(--buttons-active-switch);
 
-        @include mixins.input_shadow(var(--buttons-active-switch));
+        @include mixins.input-shadow(var(--buttons-active-switch));
 
         &::after {
-          @include mixins.input_checked(10, 4);
+          @include mixins.input-checked(10, 4);
           border: solid var(--white-primary);
           border-width: rem.rem_calc(0 2 2 0);
           transform: rotate(45deg);
@@ -38,22 +38,22 @@
     }
 
     &:not(:checked):not(.bmb_checkbox-input-indeterminate) {
-      @include focus_mark(rgb(var(--color-charade-900)));
+      @include focus-mark(rgb(var(--color-charade-900)));
 
       & + .bmb_checkbox-mark {
-        @include mixins.input_shadow(rgb(var(--color-charade-900)));
+        @include mixins.input-shadow(rgb(var(--color-charade-900)));
       }
     }
 
     &-indeterminate {
-      @include mixins.input_shadow(var(--buttons-active-switch));
+      @include mixins.input-shadow(var(--buttons-active-switch));
 
       & + .bmb_checkbox-mark {
         background-color: var(--buttons-active-switch);
         border-color: var(--buttons-active-switch);
 
         &::after {
-          @include mixins.input_checked(2, 12);
+          @include mixins.input-checked(2, 12);
           position: absolute;
           background-color: var(--white-primary);
           margin: 0;
@@ -61,17 +61,17 @@
           left: 1px;
         }
 
-        @include mixins.input_shadow(var(--buttons-active-switch));
+        @include mixins.input-shadow(var(--buttons-active-switch));
       }
 
       &:not(:checked) {
-        @include focus_mark(var(--buttons-active-switch));
+        @include focus-mark(var(--buttons-active-switch));
       }
     }
   }
 
   &-mark {
-    @include mixins.input_mark(
+    @include mixins.input-mark(
       var(--general_contrasts-75),
       var(--bmb-radius-xs)
     );

--- a/projects/ds-ng/src/lib/components/bmb-container-button/bmb-container-button.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-container-button/bmb-container-button.component.scss
@@ -2,13 +2,13 @@
 @use '../../../assets/styles/base/rem' as rem;
 @use '../../../assets/styles/base/mixins' as mixins;
 
-@mixin buttonClass() {
+@mixin button-class() {
   > .bmb_check-external-link-button > .bmb_check-external-link-button-element {
     @content;
   }
 }
 
-@mixin button_container() {
+@mixin button-container() {
   align-items: center;
   display: flex;
   gap: rem.rem_calc(16);
@@ -28,7 +28,7 @@
 
 .bmb_container-button {
   &-error.bmb_container-button-wrapper {
-    @include buttonClass() {
+    @include button-class() {
       border-color: var(--red-primary);
       color: var(--red-primary);
       cursor: not-allowed;
@@ -40,7 +40,7 @@
   }
 
   &-disabled.bmb_container-button-wrapper {
-    @include buttonClass() {
+    @include button-class() {
       background-color: var(--containers-main);
       color: var(--general_contrasts-50);
       cursor: not-allowed;
@@ -81,7 +81,7 @@
 
   &-left {
     flex: 1;
-    @include button_container();
+    @include button-container();
 
     .bmb_icon-figure {
       width: 100%;
@@ -94,17 +94,17 @@
   }
 
   &-right {
-    @include button_container();
+    @include button-container();
 
     &-menu {
       .bmb_dropdown_menu-list {
-        @include mixins.dropdown_menu_left(250);
+        @include mixins.dropdown-menu-left(250);
       }
     }
   }
 
   &-square.bmb_container-button-wrapper {
-    @include buttonClass() {
+    @include button-class() {
       flex-flow: column;
       justify-content: center;
       min-height: rem.rem_calc(148);
@@ -137,7 +137,7 @@
   }
 
   &-small.bmb_container-button-wrapper {
-    @include buttonClass() {
+    @include button-class() {
       min-width: rem.rem_calc(160);
       padding: rem.rem_calc(16);
       width: auto;
@@ -150,7 +150,7 @@
 
   &-alternative.bmb_container-button-wrapper {
     &:not(.bmb_container-button-disabled):not(.bmb_container-button-error) {
-      @include buttonClass() {
+      @include button-class() {
         &:hover {
           background-color: var(--general_contrasts-15);
         }
@@ -158,25 +158,25 @@
     }
 
     &.bmb_container-button-disabled.bmb_container-button-wrapper {
-      @include buttonClass() {
+      @include button-class() {
         background-color: var(--general_contrasts-15);
       }
     }
 
     &.bmb_container-button-disabled.bmb_container-button-wrapper {
-      @include buttonClass() {
+      @include button-class() {
         background-color: var(--general_contrasts-15);
       }
     }
 
-    @include buttonClass() {
+    @include button-class() {
       background-color: var(--general_contrasts-25);
     }
   }
 
   &-wrapper {
     &:not(.bmb_container-button-disabled):not(.bmb_container-button-error) {
-      @include buttonClass() {
+      @include button-class() {
         &:hover {
           background-color: var(--general_contrasts-50);
         }
@@ -194,7 +194,7 @@
       }
     }
 
-    @include buttonClass() {
+    @include button-class() {
       align-items: center;
       background-color: var(--containers-container-button);
       border: rem.rem_calc(1) solid var(--general_contrasts-50);
@@ -213,7 +213,7 @@
 
   .bmb_container-button-right-action {
     &:not(.bmb_container-button-wrapper) {
-      @include buttonClass() {
+      @include button-class() {
         align-items: center;
         background-color: inherit;
         border: none;

--- a/projects/ds-ng/src/lib/components/bmb-external-link/bmb-external-link.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-external-link/bmb-external-link.component.scss
@@ -32,7 +32,7 @@
     position: relative;
 
     &-list {
-      @include mixins.dropdown_menu_left(250);
+      @include mixins.dropdown-menu-left(250);
     }
   }
 }

--- a/projects/ds-ng/src/lib/components/bmb-fab/bmb-fab.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-fab/bmb-fab.component.scss
@@ -2,8 +2,8 @@
 @use '../../../assets/styles/base/rem' as rem;
 @use '../../../assets/styles/base/fonts' as fonts;
 
-@mixin fabMitec() {
-  @include mixins.fabContent();
+@mixin fab-mitec() {
+  @include mixins.fab-content();
   background-color: var(--buttons-alternative-normal);
   box-shadow: var(--bmb-box-shadow-3);
   color: var(--buttons-primary-normal);
@@ -36,8 +36,8 @@
     flex-direction: column;
 
     &-small-normal {
-      @include mixins.fabSize(small, normal);
-      @include fabMitec();
+      @include mixins.fab-size(small, normal);
+      @include fab-mitec();
 
       ~ .bmb_fab-mitec-text {
         @include fonts.font(2, medium);
@@ -46,8 +46,8 @@
     }
 
     &-large-normal {
-      @include mixins.fabSize(large, normal);
-      @include fabMitec();
+      @include mixins.fab-size(large, normal);
+      @include fab-mitec();
 
       ~ .bmb_fab-mitec-text {
         @include fonts.font(4, medium);
@@ -57,23 +57,23 @@
   }
 
   &-small-normal {
-    @include mixins.fabInput();
-    @include mixins.fabSize(small, normal);
+    @include mixins.fab-input();
+    @include mixins.fab-size(small, normal);
   }
 
   &-small-extended {
-    @include mixins.fabInput();
-    @include mixins.fabSize(small, extended);
+    @include mixins.fab-input();
+    @include mixins.fab-size(small, extended);
   }
 
   &-large-normal {
-    @include mixins.fabInput();
-    @include mixins.fabSize(large, normal);
+    @include mixins.fab-input();
+    @include mixins.fab-size(large, normal);
   }
 
   &-large-extended {
-    @include mixins.fabInput();
-    @include mixins.fabSize(large, extended);
+    @include mixins.fab-input();
+    @include mixins.fab-size(large, extended);
   }
 }
 

--- a/projects/ds-ng/src/lib/components/bmb-frequent-apps-selector/bmb-frequent-apps-selector.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-frequent-apps-selector/bmb-frequent-apps-selector.component.scss
@@ -58,7 +58,7 @@
         scroll-snap-align: center;
         width: clamp(rem.rem_calc(150), 45%, rem.rem_calc(250));
 
-        @media (width <= 1000px) {
+        @include mixins.check-for-mobile() {
           .bmb_interactive_icon-title {
             word-break: break-word;
             -webkit-hyphens: auto;

--- a/projects/ds-ng/src/lib/components/bmb-icon-status/bmb-icon-status.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-icon-status/bmb-icon-status.component.scss
@@ -7,7 +7,7 @@ $colors: (
   'error': var(--alert-error),
 );
 
-@mixin statusAppearances($color) {
+@mixin status-appearances($color) {
   background-color: $color;
 }
 
@@ -23,7 +23,7 @@ $colors: (
 
     @each $name, $color in $colors {
       &-#{$name} {
-        @include statusAppearances($color);
+        @include status-appearances($color);
       }
     }
   }

--- a/projects/ds-ng/src/lib/components/bmb-input-phone-number/bmb-input-phone-number.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-input-phone-number/bmb-input-phone-number.component.scss
@@ -7,13 +7,13 @@
 
   &-container {
     display: flex;
-    @include mixins.normal_input();
+    @include mixins.normal-input();
 
     &-error {
-      @include mixins.error_input();
+      @include mixins.error-input();
     }
 
-    @include mixins.normal_input_focus();
+    @include mixins.normal-input-focus();
 
     .bmb_input-validator-label {
       display: none;

--- a/projects/ds-ng/src/lib/components/bmb-input-tags/bmb-input-tags.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-input-tags/bmb-input-tags.component.scss
@@ -5,15 +5,15 @@
   &-container {
     display: flex;
     flex-direction: column;
-    @include mixins.normal_input();
+    @include mixins.normal-input();
     min-height: rem.rem_calc(48);
     height: auto;
 
     &-error {
-      @include mixins.error_input();
+      @include mixins.error-input();
     }
 
-    @include mixins.normal_input_focus();
+    @include mixins.normal-input-focus();
   }
 
   &-dialog {

--- a/projects/ds-ng/src/lib/components/bmb-input/bmb-input-content/bmb-input-content.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-input/bmb-input-content/bmb-input-content.component.scss
@@ -2,19 +2,19 @@
 @use '../../../../assets/styles/base/mixins' as mixins;
 @use '../../../../assets/styles/base/rem' as rem;
 
-@mixin placeholder_padding($padding) {
+@mixin placeholder-padding($padding) {
   padding-left: $padding;
 }
 
 @mixin input($type: normal) {
-  @include mixins.resetElement();
+  @include mixins.reset-element();
   @include fonts.font(4, regular);
   color: var(--general_contrasts-100);
 
   &:focus,
   &:focus,
   &:hover {
-    @include mixins.focusElement();
+    @include mixins.focus-element();
   }
 
   @if $type == 'simple' {
@@ -29,7 +29,7 @@
     transition: all 0.3s ease;
 
     &.bmb_field-input-error {
-      @include mixins.error_input();
+      @include mixins.error-input();
     }
 
     &:focus,
@@ -48,18 +48,18 @@
       border-bottom: rem.rem_calc(2) solid var(--general_contrasts-50);
     }
   } @else {
-    @include placeholder_padding(var(--bmb-spacing-s));
-    @include mixins.normal_input();
+    @include placeholder-padding(var(--bmb-spacing-s));
+    @include mixins.normal-input();
 
     &.bmb_field-input-error {
-      @include mixins.error_input();
+      @include mixins.error-input();
     }
 
-    @include mixins.normal_input_focus();
+    @include mixins.normal-input-focus();
   }
 
   &::placeholder {
-    @include mixins.input_placeholder();
+    @include mixins.input-placeholder();
   }
 }
 
@@ -83,11 +83,11 @@
     transform: translateY(-50%);
 
     ~ .bmb_field-input-normal {
-      @include placeholder_padding(rem.rem_calc(39));
+      @include placeholder-padding(rem.rem_calc(39));
     }
 
     ~ .bmb_field-input-simple {
-      @include placeholder_padding(rem.rem_calc(31));
+      @include placeholder-padding(rem.rem_calc(31));
     }
 
     &-simple {

--- a/projects/ds-ng/src/lib/components/bmb-input/bmb-input-validator/bmb-input-validator.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-input/bmb-input-validator/bmb-input-validator.component.scss
@@ -52,17 +52,17 @@
 
     &-helper {
       &-normal {
-        @include mixins.normal_helper_text();
+        @include mixins.normal-helper-text();
       }
 
       &-simple {
-        @include mixins.helper_text();
+        @include mixins.helper-text();
         color: var(--general_contrasts-50);
       }
     }
 
     &-error {
-      @include mixins.error_helper_text();
+      @include mixins.error-helper-text();
     }
   }
 

--- a/projects/ds-ng/src/lib/components/bmb-legend/bmb-legend.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-legend/bmb-legend.component.scss
@@ -2,7 +2,7 @@
 @use '../../../assets/styles/base/mixins' as mixins;
 @use '../../../assets/styles/base/rem' as rem;
 
-@mixin fontStyle {
+@mixin font-style {
   @include fonts.font(3, regular);
   color: RGBA(var(--color-charade-950));
 }
@@ -47,12 +47,12 @@ $variants: (
 
   &-label {
     grid-area: label;
-    @include fontStyle();
+    @include font-style();
   }
 
   &-value {
     grid-area: value;
-    @include fontStyle();
+    @include font-style();
   }
 }
 

--- a/projects/ds-ng/src/lib/components/bmb-modal/bmb-native-modal.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-modal/bmb-native-modal.component.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/styles/base/rem' as rem;
+@use '../../../assets/styles/base/mixins' as mixins;
 
 $modalSize: (
   'x-small': rem.rem_calc(472),
@@ -60,7 +61,7 @@ $modalSize: (
     gap: var(--bmb-spacing-m);
     flex-wrap: wrap;
 
-    @media (max-width: 1000px) {
+    @include mixins.check-for-mobile() {
       .bmb_btn {
         flex: 1 1 100%;
       }

--- a/projects/ds-ng/src/lib/components/bmb-multi-dot-paginator/bmb-multi-dot-paginator-item/bmb-multi-dot-paginator-item.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-multi-dot-paginator/bmb-multi-dot-paginator-item/bmb-multi-dot-paginator-item.component.scss
@@ -1,6 +1,8 @@
 @use '../../../../assets/styles/base/mixins' as mixins;
+@use '../../../../assets/styles/base/vars' as vars;
+@use '../../../../assets/styles/base/rem' as rem;
 
-@mixin previewBlock() {
+@mixin preview-block() {
   opacity: 0.5;
 
   .bmb_multi-dot-paginator-item {
@@ -13,25 +15,29 @@ bmb-multi-dot-paginator-item {
   width: calc((100% / var(--numberOfElements)) - 6rem);
   display: block;
 
-  @media (width <= 999px) {
+  @include mixins.check-for-mobile() {
     &.bmb_multi-dot-paginator-item-active ~ * {
-      @include previewBlock();
+      @include preview-block();
     }
   }
 
-  @media (999px < width <= 1999px) {
+  @include mixins.media-range-query(
+    vars.$breakpoint_min_web,
+    rem.rem_calc(1999px),
+    false
+  ) {
     &.bmb_multi-dot-paginator-item-active + * ~ * {
-      @include previewBlock();
+      @include preview-block();
     }
   }
 
   @media (1999px < width) {
     &.bmb_multi-dot-paginator-item-active + * + * ~ * {
-      @include previewBlock();
+      @include preview-block();
     }
   }
 
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     width: calc((50% / var(--numberOfElements)) - 3rem);
   }
 

--- a/projects/ds-ng/src/lib/components/bmb-multi-dot-paginator/bmb-multi-dot-paginator.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-multi-dot-paginator/bmb-multi-dot-paginator.component.scss
@@ -57,7 +57,7 @@
         0px
       );
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         --child-size: calc(50% / var(--numberOfElements) - 3rem);
       }
 
@@ -92,13 +92,13 @@
       }
 
       &:last-child .bmb_multi-dot-paginator-dot::after {
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           width: rem.rem_calc(14);
         }
       }
 
       &-active {
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           + .bmb_multi-dot-paginator-list-item {
             .bmb_multi-dot-paginator-dot {
               background-color: var(--general_contrasts-main-selection);
@@ -169,7 +169,7 @@
           rem.rem_calc(0 0 4 0) var(--general_contrasts-main-selection);
         z-index: -1;
 
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           width: rem.rem_calc(30);
         }
 

--- a/projects/ds-ng/src/lib/components/bmb-portal/bmb-portal.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-portal/bmb-portal.component.scss
@@ -16,12 +16,12 @@ $toast-out-duration: 0.5s;
   flex-flow: column;
 }
 
-@mixin topMixin() {
+@mixin top-mixin() {
   @include base();
   top: rem.rem_calc(16);
 }
 
-@mixin bottomMixin() {
+@mixin bottom-mixin() {
   @include base();
   bottom: rem.rem_calc(16);
 }
@@ -101,7 +101,7 @@ $toast-out-duration: 0.5s;
 .bmb_portal {
   &-top-right {
     right: rem.rem_calc(16);
-    @include topMixin();
+    @include top-mixin();
 
     &.has-toast {
       overflow: hidden;
@@ -119,7 +119,7 @@ $toast-out-duration: 0.5s;
 
   &-top-left {
     left: rem.rem_calc(16);
-    @include topMixin();
+    @include top-mixin();
 
     bmb-toast {
       animation: slideBounceLeftToRight $toast-in-duration ease-out forwards;
@@ -132,7 +132,7 @@ $toast-out-duration: 0.5s;
 
   &-top-center {
     left: 50%;
-    @include topMixin();
+    @include top-mixin();
 
     > * {
       transform: translateX(-50%);
@@ -149,7 +149,7 @@ $toast-out-duration: 0.5s;
 
   &-bottom-right {
     right: rem.rem_calc(16);
-    @include bottomMixin();
+    @include bottom-mixin();
 
     &.has-toast {
       overflow: hidden;
@@ -166,7 +166,7 @@ $toast-out-duration: 0.5s;
 
   &-bottom-left {
     left: rem.rem_calc(16);
-    @include bottomMixin();
+    @include bottom-mixin();
 
     bmb-toast {
       animation: slideBounceLeftToRight $toast-in-duration ease-out forwards;
@@ -179,7 +179,7 @@ $toast-out-duration: 0.5s;
 
   &-bottom-center {
     left: 50%;
-    @include bottomMixin();
+    @include bottom-mixin();
 
     > * {
       transform: translateX(-50%);

--- a/projects/ds-ng/src/lib/components/bmb-push-notification/bmb-push-notification-item/bmb-push-notification-item.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-push-notification/bmb-push-notification-item/bmb-push-notification-item.component.scss
@@ -2,12 +2,12 @@
 @use '../../../../assets/styles/base/fonts' as fonts;
 @use '../../../../assets/styles/base/mixins' as mixins;
 
-@mixin textEllipsis() {
+@mixin text-ellipsis() {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     white-space: initial;
     text-overflow: initial;
   }
@@ -52,7 +52,7 @@ $types: (
   &-full-color {
     border-radius: rem.rem_calc(50);
 
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       border-radius: var(--bmb-radius-s);
     }
 
@@ -114,7 +114,7 @@ $types: (
     &-legend {
       flex: 1;
       overflow: hidden;
-      @include textEllipsis();
+      @include text-ellipsis();
     }
 
     &-date {
@@ -128,13 +128,13 @@ $types: (
     font-weight: 400;
     color: RGBA(var(--color-white-primary), 0.5);
     margin-bottom: var(--bmb-spacing-xs);
-    @include textEllipsis();
+    @include text-ellipsis();
   }
 
   &-content {
     @include fonts.font(3, regular);
     margin-bottom: 0;
-    @include textEllipsis();
+    @include text-ellipsis();
   }
 
   &-icon {
@@ -198,7 +198,7 @@ $types: (
       line-height: 0;
       white-space: nowrap;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         line-height: inherit;
         opacity: 1;
         white-space: initial;

--- a/projects/ds-ng/src/lib/components/bmb-radial/bmb-radial.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-radial/bmb-radial.component.scss
@@ -1,12 +1,12 @@
 @use '../../../assets/styles/base/mixins' as mixins;
 @use '../../../assets/styles/base/rem' as rem;
 
-@mixin focus_mark($color) {
+@mixin focus-mark($color) {
   &:hover,
   &:focus,
   &:focus-visible {
     & + .bmb_radio-mark::before {
-      @include mixins.shadow_mark($color);
+      @include mixins.shadow-mark($color);
       left: rem.rem_calc(-11) !important;
     }
   }
@@ -20,15 +20,15 @@
     position: absolute;
 
     &:is(:checked) {
-      @include focus_mark(var(--buttons-active-switch));
+      @include focus-mark(var(--buttons-active-switch));
 
       + .bmb_radio-mark {
         border: rem.rem_calc(2) solid var(--buttons-active-switch);
 
-        @include mixins.input_shadow(var(--buttons-active-switch));
+        @include mixins.input-shadow(var(--buttons-active-switch));
 
         &::after {
-          @include mixins.input_checked(12, 12);
+          @include mixins.input-checked(12, 12);
           margin-top: rem.rem_calc(4);
           background-color: var(--buttons-active-switch);
           border-radius: 100%;
@@ -37,16 +37,16 @@
     }
 
     &:not(:checked) {
-      @include focus_mark(rgb(var(--color-charade-900)));
+      @include focus-mark(rgb(var(--color-charade-900)));
 
       & + .bmb_radio-mark {
-        @include mixins.input_shadow(rgb(var(--color-charade-900)));
+        @include mixins.input-shadow(rgb(var(--color-charade-900)));
       }
     }
   }
 
   &-mark {
-    @include mixins.input_mark(var(--general_contrasts-100), 100%);
+    @include mixins.input-mark(var(--general_contrasts-100), 100%);
     width: rem.rem_calc(24);
     height: rem.rem_calc(24);
     margin: 0;

--- a/projects/ds-ng/src/lib/components/bmb-sidebar/bmb-sidebar.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-sidebar/bmb-sidebar.component.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@mixin isOpen() {
+@mixin is-open() {
   animation: bounceChildrenMobile 0.6s ease-out forwards;
   height: 100vh;
   overflow: auto;
@@ -87,7 +87,7 @@
   }
 }
 
-@mixin isOpenMobile() {
+@mixin is-open-mobile() {
   $_position: rem.rem_calc(64);
   animation: bounceRightMobile 0.6s ease-out forwards;
   height: calc(100vh - $_position);
@@ -116,7 +116,7 @@
   margin: rem.rem_calc(16 0 0 0);
 }
 
-@mixin openModal() {
+@mixin open-modal() {
   display: flex;
   width: rem.rem_calc(264);
   opacity: 1;
@@ -159,12 +159,12 @@
       background-color: rgb(var(--color-black-primary));
       color: rgb(var(--color-white-primary));
 
-      @include mixins.hiddenForNoMobile();
+      @include mixins.hidden-for-no-mobile();
     }
 
     &.bmb_sidebar-open {
       display: block;
-      @include isOpenMobile();
+      @include is-open-mobile();
     }
 
     .bmb_sidebar-header {
@@ -259,7 +259,7 @@
       }
     }
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       display: block;
     }
 
@@ -268,14 +268,14 @@
 
       &:hover {
         .bmb_sidebar-children {
-          @include openModal();
+          @include open-modal();
           animation: bounceChildren 0.5s ease-out forwards;
         }
       }
     }
 
     .bmb_sidebar-children:hover {
-      @include openModal();
+      @include open-modal();
     }
   }
 

--- a/projects/ds-ng/src/lib/components/bmb-switch/bmb-switch.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-switch/bmb-switch.component.scss
@@ -1,7 +1,7 @@
 @use '../../../assets/styles/base/rem' as rem;
 @use '../../../assets/styles/base/fonts' as fonts;
 
-@mixin translate_element() {
+@mixin translate-element() {
   transform: translate(rem.rem_calc(32), rem.rem_calc(0));
 }
 
@@ -38,11 +38,11 @@
       background-color: var(--buttons-active-switch);
 
       &::after {
-        @include translate_element();
+        @include translate-element();
       }
 
       .material-symbols-rounded {
-        @include translate_element();
+        @include translate-element();
       }
 
       &:hover {

--- a/projects/ds-ng/src/lib/components/bmb-table-lite/bmb-table-lite.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-table-lite/bmb-table-lite.component.scss
@@ -31,7 +31,7 @@
 
     &-top,
     &-bottom {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         .bmb_table_lite-header {
           height: 30%;
           width: 100%;
@@ -44,7 +44,7 @@
 
     &-left,
     &-right {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         flex-flow: row;
 
         .bmb_table_lite-header {
@@ -57,7 +57,7 @@
     }
 
     &-right {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         flex-flow: row-reverse;
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-tables/bmb-tables.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-tables/bmb-tables.component.scss
@@ -11,7 +11,7 @@
   box-sizing: border-box;
   container-type: inline-size;
 
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     height: 100%;
   }
 
@@ -36,7 +36,7 @@
 
     &-top,
     &-bottom {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         .bmb_table-header {
           height: 30%;
           width: 100%;
@@ -50,7 +50,7 @@
 
     &-left,
     &-right {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         flex-flow: row;
 
         .bmb_table-header {
@@ -64,7 +64,7 @@
     }
 
     &-right {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         flex-flow: row-reverse;
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-tabs/bmb-tabs.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-tabs/bmb-tabs.component.scss
@@ -82,24 +82,24 @@
     }
 
     &-mobile {
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         display: block;
       }
 
       &-remove {
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           display: none;
         }
       }
     }
 
     &-desktop {
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         display: block;
       }
 
       &-remove {
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           display: none;
         }
       }

--- a/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.scss
@@ -25,7 +25,7 @@ $colors: (
   'creative_ripelemon': var(--creative-use-ripelemon)
 );
 
-@mixin tagVariant($name, $color) {
+@mixin tag-variant($name, $color) {
   background-color: $color;
   border-color: $color;
   color: var(--general_contrasts-5);
@@ -70,7 +70,7 @@ $colors: (
 
   @each $name, $color in $colors {
     &-#{$name} {
-      @include tagVariant($name, $color);
+      @include tag-variant($name, $color);
     }
   }
 }

--- a/projects/ds-ng/src/lib/components/bmb-title-content/bmb-title-content.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-title-content/bmb-title-content.component.scss
@@ -4,7 +4,7 @@
 $font-sizes: 1, 2, 3, 4, 4_5, 5, 6, 7, 8, 9, 10, 11, 12;
 $font-weights: 100, 200, 300, 400, 500, 600, 700, 800, 900;
 
-@mixin fontSizes() {
+@mixin font-sizes() {
   @each $size in $font-sizes {
     &-#{$size} {
       @include fonts.font($size, regular);
@@ -12,7 +12,7 @@ $font-weights: 100, 200, 300, 400, 500, 600, 700, 800, 900;
   }
 }
 
-@mixin fontWeights() {
+@mixin font-weights() {
   @each $font-weight in $font-weights {
     &-#{$font-weight} {
       font-weight: $font-weight;
@@ -57,15 +57,15 @@ $font-weights: 100, 200, 300, 400, 500, 600, 700, 800, 900;
 
       &-title {
         color: var(--general_contrasts-100);
-        @include fontSizes();
-        @include fontWeights();
+        @include font-sizes();
+        @include font-weights();
         @include centered();
       }
 
       &-subtitle {
         color: var(--general_contrasts-75);
-        @include fontSizes();
-        @include fontWeights();
+        @include font-sizes();
+        @include font-weights();
         @include centered();
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar-item/bmb-top-bar-item.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar-item/bmb-top-bar-item.component.scss
@@ -9,7 +9,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @include mixins.checkForMobile() {
+  @include mixins.check-for-mobile() {
     padding: rem.rem_calc(8) rem.rem_calc(16);
     width: 100vw;
     box-sizing: border-box;
@@ -29,7 +29,7 @@
     color: RGBA(var(--color-charade-500));
     text-decoration: none;
 
-    @include mixins.checkForMobile() {
+    @include mixins.check-for-mobile() {
       color: RGBA(var(--color-white-primary));
     }
   }

--- a/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar-user-section/bmb-top-bar-user-section.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar-user-section/bmb-top-bar-user-section.component.scss
@@ -4,7 +4,7 @@
 .bmb_top-bar-user-section {
   color: rgb(var(--color-white-primary));
 
-  @include mixins.checkForMobile() {
+  @include mixins.check-for-mobile() {
     gap: var(--bmb-spacing-s);
   }
 
@@ -26,7 +26,7 @@
     }
 
     .bmb_dropdown_menu {
-      @include mixins.dropdown_menu_left(250);
+      @include mixins.dropdown-menu-left(250);
     }
   }
 
@@ -34,18 +34,18 @@
     display: block;
     line-height: 0;
 
-    @include mixins.hiddenForMobile();
+    @include mixins.hidden-for-mobile();
   }
 
   &-mobile {
     display: block;
     line-height: 0;
 
-    @include mixins.hiddenForNoMobile();
+    @include mixins.hidden-for-no-mobile();
   }
 
   .bmb_user-summary_content-wrapper {
-    @include mixins.hiddenForMobile();
+    @include mixins.hidden-for-mobile();
 
     &-title {
       @include fonts.font(3, regular);

--- a/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-top-bar/bmb-top-bar.component.scss
@@ -40,7 +40,7 @@
   height: 64px;
 
   &-sidebar {
-    @include mixins.checkForMobile() {
+    @include mixins.check-for-mobile() {
       padding-left: rem.rem_calc(48);
     }
   }
@@ -50,7 +50,7 @@
   }
 
   &-animated {
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       width: rem.rem_calc(416);
       animation: expandWidthSmooth 2s ease-out 1s forwards;
       margin: auto;
@@ -68,7 +68,7 @@
     display: flex;
     align-items: center;
     gap: rem.rem_calc(4);
-    @include mixins.hiddenForMobile();
+    @include mixins.hidden-for-mobile();
   }
 
   &-button-menu {
@@ -125,7 +125,7 @@
     width: auto;
     line-height: 0;
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       width: max-content;
     }
 
@@ -154,14 +154,14 @@
     flex: 1;
     justify-content: center;
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       justify-content: start;
     }
 
     h1 {
       @include fonts.font(6, regular);
 
-      @include mixins.checkForMobile(false) {
+      @include mixins.check-for-mobile(false) {
         display: flex;
       }
     }
@@ -171,7 +171,7 @@
       border-left: rem.rem_calc(1) solid RGBA(var(--color-white-primary));
       display: none;
 
-      @include mixins.checkForMobile(false) {
+      @include mixins.check-for-mobile(false) {
         display: inline-block;
         max-width: max-content;
         padding-left: rem.rem_calc(16);
@@ -185,7 +185,7 @@
     display: flex;
     gap: rem.rem_calc(10);
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       flex: auto;
       max-width: max-content;
     }
@@ -199,7 +199,7 @@
     align-items: center;
 
     &-open {
-      @include mixins.checkForMobile() {
+      @include mixins.check-for-mobile() {
         transition: opacity 0.3s ease;
         position: absolute;
         top: 100%;
@@ -231,7 +231,7 @@
       }
     }
 
-    @include mixins.checkForMobile(false) {
+    @include mixins.check-for-mobile(false) {
       display: flex;
       justify-content: inherit;
     }

--- a/projects/ds-ng/src/lib/components/bmb-totp/bmb-totp.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-totp/bmb-totp.component.scss
@@ -89,10 +89,10 @@
   }
 
   &-helper {
-    @include mixins.normal_helper_text();
+    @include mixins.normal-helper-text();
   }
 
   &-error {
-    @include mixins.error_helper_text();
+    @include mixins.error-helper-text();
   }
 }

--- a/projects/ds-ng/src/lib/components/bmb-value-counter/bmb-value-counter.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-value-counter/bmb-value-counter.component.scss
@@ -2,7 +2,7 @@
 @use '../../../assets/styles/base/mixins' as mixins;
 @use '../../../assets/styles/base/rem' as rem;
 
-@mixin fontStyle {
+@mixin font-style {
   @include fonts.font(4, regular);
   color: RGBA(var(--color-charade-950));
 }
@@ -13,13 +13,13 @@
   gap: rem.rem_calc(8);
 
   &-label {
-    @include fontStyle();
+    @include font-style();
     flex: 1;
   }
 
   &-progress,
   &-slash {
-    @include fontStyle();
+    @include font-style();
   }
 
   &-value {

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/bmb-web-templates.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/bmb-web-templates.component.scss
@@ -13,7 +13,7 @@
   display: grid;
   gap: 0;
   min-height: 100dvh;
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     height: 100dvh;
     overflow: hidden;
   }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/aside-first-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/aside-first-card.scss
@@ -10,12 +10,12 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     gap: 0;
   }
 
   &.bmb_web-template {
-    @include mixins.media-query(1000, 'min') {
+    @include mixins.check-for-mobile(false) {
       height: auto;
       overflow: auto;
     }
@@ -34,7 +34,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -44,11 +44,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -72,12 +72,12 @@
       margin: 0 auto;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
       }
 
@@ -85,7 +85,7 @@
         padding: 0;
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/aside-light-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/aside-light-card.scss
@@ -10,7 +10,7 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -29,7 +29,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -39,11 +39,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -68,17 +68,17 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
         gap: 0 0 var(--bmb-spacing-m);
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }
@@ -89,7 +89,7 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         border: rem.rem_calc(1) solid RGBA(var(--color-charade-100));
         border-radius: 0 var(--bmb-radius-m) var(--bmb-radius-m) 0;
       }
@@ -106,7 +106,7 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         border-radius: var(--bmb-radius-m) 0 0 var(--bmb-radius-m);
       }
     }
@@ -124,7 +124,7 @@
       }
 
       &-main {
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           border: rem.rem_calc(1) solid RGBA(var(--color-charade-900));
         }
       }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/full-width-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/full-width-card.scss
@@ -12,7 +12,7 @@
     'aside';
   gap: 1rem;
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 2fr 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -35,7 +35,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -44,11 +44,11 @@
         width: 100%;
         box-sizing: border-box;
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -73,7 +73,7 @@
       overflow: auto;
       border: rem.rem_calc(1) solid RGBA(var(--color-charade-300));
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-left: 0;
         border-radius: 0 var(--bmb-radius-m) var(--bmb-radius-m) 0;
         margin-bottom: 0;
@@ -82,7 +82,7 @@
 
       &-container {
         overflow: auto;
-        @include mixins.media-query(1000, 'min') {
+        @include mixins.check-for-mobile(false) {
           padding-left: rem.rem_calc(88);
         }
       }
@@ -97,7 +97,7 @@
       overflow: auto;
       border: rem.rem_calc(1) solid RGBA(var(--color-charade-300));
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin: 0;
         border-radius: var(--bmb-radius-m) 0 0 var(--bmb-radius-m);
         border-width: rem.rem_calc(1) 0 0 rem.rem_calc(1);

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/justify-width-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/justify-width-card.scss
@@ -10,7 +10,7 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -29,7 +29,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -39,11 +39,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -68,12 +68,12 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
       }
 
@@ -81,7 +81,7 @@
         padding: 0;
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/single-column-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/single-column-card.scss
@@ -10,7 +10,7 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -29,7 +29,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -39,11 +39,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -68,12 +68,12 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
       }
 
@@ -81,7 +81,7 @@
         padding: 0;
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/single-column-tab.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/single-column-tab.scss
@@ -10,7 +10,7 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -29,7 +29,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -39,11 +39,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -68,12 +68,12 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
       }
 
@@ -81,7 +81,7 @@
         padding: 0;
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }

--- a/projects/ds-ng/src/lib/components/bmb-web-templates/styles/two-aside-card.scss
+++ b/projects/ds-ng/src/lib/components/bmb-web-templates/styles/two-aside-card.scss
@@ -10,7 +10,7 @@
     'header'
     'content';
   @include fonts.font(3, regular);
-  @include mixins.media-query(1000, 'min') {
+  @include mixins.check-for-mobile(false) {
     grid-template-columns: 1fr;
     grid-template-rows: 71px max-content 1fr;
     gap: 0;
@@ -29,7 +29,7 @@
       padding: var(--bmb-spacing-l);
       grid-area: header;
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         margin-bottom: var(--bmb-spacing-m);
       }
 
@@ -39,11 +39,11 @@
         box-sizing: border-box;
         max-width: rem.rem_calc(1600);
 
-        @include mixins.media-query(999, 'max') {
+        @include mixins.check-for-mobile() {
           padding-left: rem.rem_calc(16);
         }
 
-        @media (width >= 1000px) and (width <= 1800px) {
+        @include mixins.media-web-templates() {
           padding-left: rem.rem_calc(80);
         }
       }
@@ -68,12 +68,12 @@
       height: 100%;
       overflow: auto;
 
-      @include mixins.media-query(999, 'max') {
+      @include mixins.check-for-mobile() {
         padding-left: rem.rem_calc(16);
         height: max-content;
       }
 
-      @include mixins.media-query(1000, 'min') {
+      @include mixins.check-for-mobile(false) {
         padding: 0 rem.rem_calc(16) rem.rem_calc(16);
       }
 
@@ -81,7 +81,7 @@
         padding: 0;
       }
 
-      @media (width >= 1000px) and (width <= 1800px) {
+      @include mixins.media-web-templates() {
         padding-left: rem.rem_calc(100);
       }
     }

--- a/projects/ds-ng/src/lib/layouts/bmb-identity-spectrum.stories.ts
+++ b/projects/ds-ng/src/lib/layouts/bmb-identity-spectrum.stories.ts
@@ -17,7 +17,7 @@ import { BmbFormValidatorComponent } from '../components/bmb-form-validator/bmb-
 import { BmbInputComponent } from '../components/bmb-input/bmb-input.component';
 
 import { IBmbNativeModal } from '../components/bmb-modal/bmb-modal.interface';
-import { BmbNativeModalService } from '../services/native-modal.service';
+import { BmbNativeModalService } from '../services/modal/native-modal.service';
 import { IBmbActionHeader } from '../types';
 
 import { BmbButtonDirective } from '../directives/bmb-button/button.directive';

--- a/projects/ds-ng/src/lib/utils/doc/utils.ts
+++ b/projects/ds-ng/src/lib/utils/doc/utils.ts
@@ -54,7 +54,7 @@ const TECHNICAL_DOC_TITLE: string = `${DESIGN_SYSTEM_TITLE} ***- Technical docum
 const TECHNICAL_DOC_REFERENCES: string = `Please remember to refer to the ${TECHNICAL_DOC_TITLE} for more details:`;
 export const STORIES_TITLE: string = 'Variant templates';
 export const TITLE_OF_CONTROLS: string = 'Properties / Events';
-const PREVIEW_TITLE: string = '👁 Preview';
+export const PREVIEW_TITLE: string = '👁 Preview';
 export const TOC_TITLE: string = 'On this page';
 export const DESCRIPTION_TITLE: string = 'Description';
 export const SPECIAL_SPECIFICATIONS_TITLE: string =
@@ -74,7 +74,13 @@ export const TOC_OBJ = {
 };
 
 export const getPageStructureForFoundationStories = (): any => {
-  return [Title({}), Description({}), Primary({}), Controls({})];
+  return [
+    Title({}),
+    Description({}),
+    Heading({ children: PREVIEW_TITLE }),
+    Primary({}),
+    Controls({}),
+  ];
 };
 
 export const getPageStructureForTemplateStories = (): any => {


### PR DESCRIPTION


## Changes proposed in this PR: 💻

- core: 
  - Se agregó liga de 'Preview' en la documentación de historias de 'Storybook'.
  - Se crearon variables de CSS para manejo de bloques de resolución de pantalla de móviles y de web. Se re-factorizó el código de estilos utilizando dichas variables y 'mixins' de revisión de resolución.
  - Se aplicó estándar de nomenclatura de 'mixins'.
  - Se implementó ajuste de clases de CSS para ancho de sección de pre-visualización y controles.
- feat(directive/layout): se re-factorizó el uso de directiva para los puntos de ruptura de dispositivos móviles o web.


## Visuals 🎴

Add screenshots of the result of your changes proposed.

## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit test before submitting.
- [x] My code resolved all of the task's acceptance criteria.
