### PR TITLE
feat(component/icon): se ajustaron los colores de 'Notification count…

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-icon/bmb-icon.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-icon/bmb-icon.stories.ts
@@ -23,10 +23,12 @@ export default {
       exclude: [
         'styleIconGoogle',
         'getFontVariationSettings',
+        'iconSvg',
         'isImage',
         'getImageStyles',
         'customIcon',
         'isSVGTemplate',
+        'loadIcon'
       ],
     },
     docs: {

--- a/projects/ds-ng/src/lib/components/bmb-icon/bmb-notification-counter-detail.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-icon/bmb-notification-counter-detail.stories.ts
@@ -13,6 +13,10 @@ export default {
       page: () => getPageStructureForFoundationStories(),
       controls: {
         exclude: [
+          'iconSvg',
+          'isSVGTemplate',
+          'loadIcon',
+          'customIcon',
           'alt',
           'fontWeight',
           'icon',

--- a/projects/ds-ng/src/lib/components/bmb-notification-counter/bmb-notification-counter.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-notification-counter/bmb-notification-counter.component.scss
@@ -15,7 +15,7 @@
     padding: rem.rem_calc(0 2);
     width: fit-content;
     @include fonts.font(1, bold);
-    color: var(--general_contrasts-50);
+    color: var(--general_contrasts-80);
     text-align: center;
     line-height: 1.2;
   }
@@ -26,7 +26,7 @@
     bottom: 0;
     right: 0;
     color: var(--white-primary);
-    background-color: rgb(var(--color-red-light));
+    background-color: var(--buttons-destructive);
     border-radius: rem.rem_calc(40);
   }
 


### PR DESCRIPTION
[DS01-2788](https://tecdemonterrey.atlassian.net/browse/DS01-2788) - Notification counter: Ajustar contraste para la prueba de Sonarqube.

## Changes proposed in this PR: 💻

- feat(component/icon): se ajustaron los colores de 'Notification counter' para ambas versiones (con y sin contenedor). Se ocultaron controles que no deben mostrarse.


## Visuals 🎴
<img width="598" height="358" alt="imagen" src="https://github.com/user-attachments/assets/c7edb3f7-2870-430e-875c-c3f9fbce4926" />
<img width="601" height="372" alt="imagen" src="https://github.com/user-attachments/assets/71d3bee1-56d8-4842-aa8d-634ae4bf892c" />

<img width="997" height="358" alt="imagen" src="https://github.com/user-attachments/assets/64cc47c2-9be0-4b7b-8143-6c1dbd1ecb26" />
<img width="988" height="364" alt="imagen" src="https://github.com/user-attachments/assets/af12d102-6359-4e55-ae21-5bcb230844c4" />



## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit test before submitting.
- [x] My code resolved all of the task's acceptance criteria.


[DS01-2788]: https://tecdemonterrey.atlassian.net/browse/DS01-2788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ