### PR TITLE
fix: pin npm to exact version 11.5.1 for consistency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      - name: Install npm 11.5.1 for Trusted Publishers
+        run: npm install -g npm@11.5.1
 
       - name: Change package file for versioning
         run: |
@@ -70,8 +70,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      - name: Install npm 11.5.1 for Trusted Publishers
+        run: npm install -g npm@11.5.1
 
       - name: Change package file for versioning
         run: |
@@ -115,8 +115,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      - name: Install npm 11.5.1 for Trusted Publishers
+        run: npm install -g npm@11.5.1
 
       - name: Change package file for versioning
         run: |
@@ -160,8 +160,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      - name: Install npm 11.5.1 for Trusted Publishers
+        run: npm install -g npm@11.5.1
 
       - name: Change package file for versioning
         run: |


### PR DESCRIPTION
Use npm@11.5.1 instead of @latest to prevent version inconsistencies across workflow runs. This ensures reliable Trusted Publishers authentication.

[DS01-XXXX](https://tecdemonterrey.atlassian.net/browse/DS01-XXXX) - ISSUE_TITLE

## Changes proposed in this PR: 💻

-

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit test before submitting.
- [ ] My code resolved all of the task's acceptance criteria.
