### PR TITLE
fix: disable provenance for private repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Publish to NPM
         run: |
           npm publish ./dist/ds-ng --tag a${{ env.ANGULAR_VERSION }} --access public
+        env:
+          NPM_CONFIG_PROVENANCE: false
 
   build-and-publish-18:
     runs-on: ubuntu-latest
@@ -95,6 +97,8 @@ jobs:
       - name: Publish to NPM
         run: |
           npm publish ./dist/ds-ng --tag a${{ env.ANGULAR_VERSION }} --access public
+        env:
+          NPM_CONFIG_PROVENANCE: false
 
   build-and-publish-19:
     runs-on: ubuntu-latest
@@ -140,6 +144,8 @@ jobs:
       - name: Publish to NPM
         run: |
           npm publish ./dist/ds-ng --tag a${{ env.ANGULAR_VERSION }} --access public
+        env:
+          NPM_CONFIG_PROVENANCE: false
 
   build-and-publish-20:
     runs-on: ubuntu-latest
@@ -184,4 +190,6 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          npm publish ./dist/ds-ng --tag a${{ env.ANGULAR_VERSION }} --access public --provenance
+          npm publish ./dist/ds-ng --tag a${{ env.ANGULAR_VERSION }} --access public
+        env:
+          NPM_CONFIG_PROVENANCE: false


### PR DESCRIPTION
Set NPM_CONFIG_PROVENANCE=false for all jobs as provenance is not supported for private repositories per npm documentation. This resolves the E422 error during publishing.

[DS01-XXXX](https://tecdemonterrey.atlassian.net/browse/DS01-XXXX) - ISSUE_TITLE

## Changes proposed in this PR: 💻

-

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit test before submitting.
- [ ] My code resolved all of the task's acceptance criteria.
