### PR TITLE
DS01-2962

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.html
@@ -10,27 +10,35 @@
     (onExpandClick)="onExpandClick.emit()"
   >
     <div class="bmb_home-notification-card-content">
-      <bmb-tabs
-        [tabs]="tabsConfig()"
-        [(selectedTabId)]="selectedTab"
-      ></bmb-tabs>
-      @switch (selectedTab()) {
-        @case (1) {
-          <bmb-alert-center-list
-            [alerts]="parsedData()"
-            [enableMultipleSelection]="false"
-            (alertSelected)="handleAlertSelected($event)"
-          />
+      @if (showAdvertisements()) {
+        <bmb-tabs
+          [tabs]="tabsConfig()"
+          [(selectedTabId)]="selectedTab"
+        ></bmb-tabs>
+        @switch (selectedTab()) {
+          @case (1) {
+            <bmb-alert-center-list
+              [alerts]="parsedData()"
+              [enableMultipleSelection]="false"
+              (alertSelected)="handleAlertSelected($event)"
+            />
+          }
+          @case (2) {
+            <bmb-alert-center-ads
+              [advertisements]="advertisements()"
+              (alertEvent)="handleAlertEvent($event)"
+            />
+          }
+          @default {
+            <div>Invalid ID selected</div>
+          }
         }
-        @case (2) {
-          <bmb-alert-center-ads
-            [advertisements]="advertisements()"
-            (alertEvent)="handleAlertEvent($event)"
-          />
-        }
-        @default {
-          <div>Invalid ID selected</div>
-        }
+      } @else {
+        <bmb-alert-center-list
+          [alerts]="parsedData()"
+          [enableMultipleSelection]="false"
+          (alertSelected)="handleAlertSelected($event)"
+        />
       }
     </div>
   </bmb-home-card>

--- a/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.spec.ts
@@ -1,17 +1,171 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BmbNotificationCardComponent } from './bmb-notification-card.component';
+import { BmbTranslationsService } from '../../services/translations/translations.service';
+import { BmbProjectionContentService } from '../../services/projection/projection.service';
+import { BmbNativeModalService } from '../../services/modal/native-modal.service';
+import { IBmbDataAlert, IBmbDataAlertsParsed } from '../bmb-alert-center/types';
+import { ComponentRef } from '@angular/core';
+import { DateTime } from 'luxon';
+import { BmbNotificationCardModalComponent } from './bmb-notification-card-modal/bmb-notification-card-modal.component';
+
+class MockBmbTranslationsService {
+  translate(key: string) {
+    return key;
+  }
+}
+
+class MockBmbProjectionContentService {
+  closeContent() {}
+}
+
+class MockBmbNativeModalService {
+  openModal(config: any) {}
+}
+
+const mockAlert: IBmbDataAlert = {
+  id: 1,
+  title: 'Test Alert',
+  description: [{ text: 'desc', type: 'paragraph' }],
+  date: '01/01/2023 10:00',
+  isRead: false,
+  time: '10:00',
+  type: 'info',
+  isFavorite: false,
+  isArchived: false,
+};
+
+const mockParsedAlert: IBmbDataAlertsParsed = {
+  ...mockAlert,
+  pDate: DateTime.fromFormat('01/01/2023 10:00', 'dd/MM/yyyy HH:mm'),
+};
 
 describe('BmbNotificationCardComponent', () => {
   let component: BmbNotificationCardComponent;
   let fixture: ComponentFixture<BmbNotificationCardComponent>;
+  let componentRef: ComponentRef<BmbNotificationCardComponent>;
+  let modalService: BmbNativeModalService;
+  let projectionService: BmbProjectionContentService;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BmbNotificationCardComponent],
+      providers: [
+        { provide: BmbTranslationsService, useClass: MockBmbTranslationsService },
+        { provide: BmbProjectionContentService, useClass: MockBmbProjectionContentService },
+        { provide: BmbNativeModalService, useClass: MockBmbNativeModalService },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(BmbNotificationCardComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    modalService = TestBed.inject(BmbNativeModalService);
+    projectionService = TestBed.inject(BmbProjectionContentService);
+
+    componentRef.setInput('data', []);
+    componentRef.setInput('advertisements', []);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('parsedData', () => {
+    it('should parse dates correctly with default format', () => {
+      componentRef.setInput('data', [mockAlert]);
+      fixture.detectChanges();
+
+      const parsed = component.parsedData();
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].pDate.isValid).toBe(true);
+      expect(parsed[0].pDate.toFormat('dd/MM/yyyy HH:mm')).toBe('01/01/2023 10:00');
+    });
+
+    it('should parse dates correctly with iso format', () => {
+        const isoDate = '2023-01-01T10:00:00';
+        const isoAlert = { ...mockAlert, date: isoDate };
+        componentRef.setInput('data', [isoAlert]);
+        componentRef.setInput('dateFormat', 'iso');
+        fixture.detectChanges();
+
+        const parsed = component.parsedData();
+        expect(parsed.length).toBe(1);
+        expect(parsed[0].pDate.isValid).toBe(true);
+        expect(parsed[0].pDate.hasSame(DateTime.fromISO(isoDate), 'minute')).toBe(true);
+      });
+  });
+
+  describe('badgeTabs', () => {
+    it('should calculate badge counts for unread items', () => {
+      const unreadAlert = { ...mockAlert, isRead: false };
+      const readAlert = { ...mockAlert, isRead: true };
+
+      componentRef.setInput('data', [unreadAlert, readAlert, unreadAlert]);
+      componentRef.setInput('advertisements', [unreadAlert]);
+      fixture.detectChanges();
+
+      const badges = component.badgeTabs();
+      expect(badges[0]).toBe(2); // 2 unread alerts
+      expect(badges[1]).toBe(1); // 1 unread advertisement
+    });
+  });
+
+  describe('tabsConfig', () => {
+    it('should configure tabs with translated titles and badges', () => {
+      componentRef.setInput('data', [{...mockAlert, isRead: false}]);
+      fixture.detectChanges();
+
+      const tabs = component.tabsConfig();
+      expect(tabs.length).toBe(2);
+      expect(tabs[0].title).toBe('notification_card.tabs.notifications');
+      expect(tabs[0].badge).toBe(1);
+      expect(tabs[1].title).toBe('notification_card.tabs.advertisements');
+    });
+  });
+
+  describe('getEmptyStateData', () => {
+    it('should return custom empty state if provided', () => {
+      const customState = { primaryText: 'Custom', showButton: true };
+      componentRef.setInput('emptyStateData', customState);
+      fixture.detectChanges();
+
+      expect(component.getEmptyStateData()).toBe(customState as any);
+    });
+
+    it('should return default empty state if not provided', () => {
+        const defaultState = component.getEmptyStateData();
+        expect(defaultState.primaryText).toBe('notification_card.empty_state.primary_text');
+        expect(defaultState.showButton).toBe(false);
+    });
+  });
+
+  describe('handleAlertEvent', () => {
+    it('should emit alertEvent', () => {
+      const spy = spyOn(component.alertEvent, 'emit');
+      component.handleAlertEvent(mockAlert);
+      expect(spy).toHaveBeenCalledWith(mockAlert);
+    });
+  });
+
+  describe('handleAlertSelected', () => {
+    it('should emit showAlertDetail, close existing projection, and open modal', () => {
+      const emitSpy = spyOn(component.showAlertDetail, 'emit');
+      const closeSpy = spyOn(projectionService, 'closeContent');
+      const openModalSpy = spyOn(modalService, 'openModal');
+
+      component.handleAlertSelected(mockParsedAlert);
+
+      expect(emitSpy).toHaveBeenCalledWith(mockParsedAlert);
+      expect(closeSpy).toHaveBeenCalled();
+      expect(openModalSpy).toHaveBeenCalledWith({
+        title: mockParsedAlert.title,
+        content: BmbNotificationCardModalComponent,
+        size: 'small',
+        inputContext: {
+          visibleAlert: mockParsedAlert,
+        },
+      });
+    });
   });
 });

--- a/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.component.ts
@@ -48,6 +48,7 @@ export class BmbNotificationCardComponent {
   maxHeight = input<string>('auto');
   emptyStateData = input<IBmbAlertEmptyState>();
   dateFormat = input<string>('dd/MM/yyyy HH:mm');
+  showAdvertisements = input<boolean>(true);
 
   alertEvent = output<IBmbDataAlert>();
   showAlertDetail = output<IBmbDataAlert>();

--- a/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.stories.ts
@@ -66,6 +66,12 @@ export default {
           'activeTab',
           'expanded',
           'tabsConfig',
+          'badgeTabs',
+          'parsedData',
+          'selectedTab',
+          'visibleAlert',
+          'getEmptyStateData',
+          'handleAlertSelected'
         ],
       },
       description: {
@@ -166,6 +172,35 @@ ${getBasicExampleBlock(
       table: {
         category: 'Events',
         type: { summary: 'alertEvent($event)', detail: typeDetail },
+      },
+    },
+    showAdvertisements: {
+      control: { type: 'boolean' },
+      description: 'Determines whether to show the advertisements tab',
+      table: {
+        category: 'Properties',
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    dateFormat: {
+      control: { type: 'text' },
+      description:
+        'Sets the date format for displaying alert dates. Accepts any valid Luxon date format string or "iso" for ISO format.',
+      table: {
+        category: 'Properties',
+        type: { summary: 'string' },
+        defaultValue: { summary: 'dd/MM/yyyy HH:mm' },
+      },
+    },
+    emptyStateData: {
+      control: { type: 'object' },
+      description:
+        'Sets the data for the empty state when there are no alerts to display',
+      table: {
+        category: 'Properties',
+        type: { summary: 'IBmbAlertEmptyState' },
+        defaultValue: { summary: '{}' },
       },
     },
     showAlertDetail: {
@@ -445,6 +480,10 @@ https://live.tec.mx/cbweek</p><p>¡Te esperamos!`,
         isArchived: false,
       },
     ],
+    showAdvertisements: true,
+    dateFormat: 'dd/MM/yyyy HH:mm',
+    hideExpandBtn: false,
+    emptyStateData: {},
     alertEvent: () => {
       console.log('alertEvent');
     },

--- a/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-notification-card/bmb-notification-card.stories.ts
@@ -503,3 +503,9 @@ https://live.tec.mx/cbweek</p><p>¡Te esperamos!`,
 type Story = StoryObj<BmbNotificationCardComponent>;
 
 export const Default: Story = {};
+
+export const NoTabs: Story = {
+  args: {
+    showAdvertisements: false,
+  },
+};


### PR DESCRIPTION
[DS01-2962](https://tecdemonterrey.atlassian.net/browse/DS01-2962) - Centro de Notificaciones: Desactivar Tabs (ya no se veran Anuncios) y poner una opción de seleccionar "todos" y marcar como leidos.

## Changes proposed in this PR: 💻

- Se agregó la opción de ocultar las tabs en el notification card

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

<img width="602" height="795" alt="image" src="https://github.com/user-attachments/assets/6f585e1a-c49c-432b-b28e-25c803412812" />

## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit test before submitting.
- [x] My code resolved all of the task's acceptance criteria.


[DS01-2962]: https://tecdemonterrey.atlassian.net/browse/DS01-2962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ