### PR TITLE
Add Conditional & Cascading Filters for bmb-filter-card Issues#979 

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.html
@@ -28,64 +28,68 @@
           }
         }
         @for (controlType of controlTypes(); track $index) {
-          <h4 class="bmb_filter_card-title">{{ controlType.title }}</h4>
-          <div class="bmb_filter_card-control">
-            @for (control of controlType.control; track $index) {
-              @switch (control.type) {
-                @case ('tag') {
-                  <bmb-tag
-                    [text]="control.label"
-                    [dismissible]="false"
-                    [enableClick]="true"
-                    [isActive]="storedValues[control.name]?.checked ?? false"
-                    (clickedTag)="controlChange(control, $event)"
-                  />
-                }
-                @case ('radial') {
-                  <bmb-radial
-                    [name]="control.name"
-                    [inputId]="control.id ?? control.name + '-' + $index"
-                    [checked]="
-                      filterForm.get(control.name)?.value === control.label
-                    "
-                    [label]="control.label"
-                    (change)="controlChange(control, $event)"
-                    [value]="control.value ?? control.name"
-                  />
-                }
-                @case ('checkbox') {
-                  <bmb-checkbox
-                    [name]="control.name"
-                    [checked]="filterForm.get(control.name)?.value"
-                    [label]="control.label"
-                    (change)="controlChange(control, $event)"
-                    [inputId]="control.id ?? control.name + '-' + $index"
-                    [value]="control.value ?? control.name"
-                  />
-                }
-                @case ('switch') {
-                  <bmb-switch
-                    [rightText]="control.rightText ?? ''"
-                    [isChecked]="filterForm.get(control.name)?.value === true"
-                    (change)="controlChange(control, $event)"
-                  />
-                }
-                @case ('dropdown') {
-                  <bmb-dropdown
-                    [placeholder]="
-                      control.placeholder ??
-                      ('filter_card.dropdown.placeholder' | translate)
-                    "
-                    [options]="control.options ?? []"
-                    [control]="getFormControl(control.name)"
-                    (onValueChange)="onValueChange($event, control.name)"
-                    [isFilterable]="!control?.isMultiSelect!"
-                    [isMultiSelect]="control?.isMultiSelect!"
-                  />
+          @if (isSectionVisible(controlType)) {
+            <h4 class="bmb_filter_card-title">{{ controlType.title }}</h4>
+            <div class="bmb_filter_card-control">
+              @for (control of controlType.control; track $index) {
+                @if (isControlVisible(control.name)) {
+                  @switch (control.type) {
+                    @case ('tag') {
+                      <bmb-tag
+                        [text]="control.label"
+                        [dismissible]="false"
+                        [enableClick]="true"
+                        [isActive]="storedValues[control.name]?.checked ?? false"
+                        (clickedTag)="controlChange(control, $event)"
+                      />
+                    }
+                    @case ('radial') {
+                      <bmb-radial
+                        [name]="control.name"
+                        [inputId]="control.id ?? control.name + '-' + $index"
+                        [checked]="
+                          filterForm.get(control.name)?.value === control.label
+                        "
+                        [label]="control.label"
+                        (change)="controlChange(control, $event)"
+                        [value]="control.value ?? control.name"
+                      />
+                    }
+                    @case ('checkbox') {
+                      <bmb-checkbox
+                        [name]="control.name"
+                        [checked]="filterForm.get(control.name)?.value"
+                        [label]="control.label"
+                        (change)="controlChange(control, $event)"
+                        [inputId]="control.id ?? control.name + '-' + $index"
+                        [value]="control.value ?? control.name"
+                      />
+                    }
+                    @case ('switch') {
+                      <bmb-switch
+                        [rightText]="control.rightText ?? ''"
+                        [isChecked]="filterForm.get(control.name)?.value === true"
+                        (change)="controlChange(control, $event)"
+                      />
+                    }
+                    @case ('dropdown') {
+                      <bmb-dropdown
+                        [placeholder]="
+                          control.placeholder ??
+                          ('filter_card.dropdown.placeholder' | translate)
+                        "
+                        [options]="getControlOptions(control)"
+                        [control]="getFormControl(control.name)"
+                        (onValueChange)="onValueChange($event, control.name)"
+                        [isFilterable]="!control?.isMultiSelect!"
+                        [isMultiSelect]="control?.isMultiSelect!"
+                      />
+                    }
+                  }
                 }
               }
-            }
-          </div>
+            </div>
+          }
         }
         @if (inLine()) {
           <footer class="bmb_filter_card-footer">

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.spec.ts
@@ -3,7 +3,11 @@ import { BmbFilterCardComponent } from './bmb-filter-card.component';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BmbIconComponent } from '../bmb-icon/bmb-icon.component';
-import { IBmbControlType } from './bmb-filter-card.interface';
+import {
+  IBmbControlType,
+  IBmbOptionRule,
+  IBmbVisibilityRule,
+} from './bmb-filter-card.interface';
 import { BmbNativeModalService } from '../../services/modal/native-modal.service';
 
 describe('BmbFilterCardComponent', () => {
@@ -86,5 +90,219 @@ describe('BmbFilterCardComponent', () => {
     const filterCardElement =
       fixture.nativeElement.querySelector('.bmb_filter_card');
     expect(filterCardElement).toBeTruthy();
+  });
+
+  describe('Conditional Filters (visibilityRules)', () => {
+    const baseControlTypes: IBmbControlType[] = [
+      {
+        title: 'Nivel',
+        control: [
+          { name: 'nivel', type: 'radial', label: 'Profesional' },
+          { name: 'nivel', type: 'radial', label: 'Preparatoria' },
+        ],
+      },
+      {
+        title: 'Tipo de evaluación',
+        control: [
+          { name: 'tipoEval', type: 'radial', label: 'Parcial' },
+          { name: 'tipoEval', type: 'radial', label: 'Final' },
+        ],
+      },
+      {
+        title: 'Departamentos',
+        control: [{ name: 'deptos', type: 'tag', label: 'Depto A' }],
+      },
+    ];
+
+    const visibilityRules: IBmbVisibilityRule[] = [
+      {
+        when: { nivel: 'Profesional' },
+        show: ['tipoEval'],
+        hide: ['deptos'],
+      },
+      {
+        when: { nivel: 'Preparatoria' },
+        show: ['deptos'],
+        hide: ['tipoEval'],
+      },
+    ];
+
+    it('should show all controls when no visibilityRules are provided', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.detectChanges();
+
+      expect(component.isControlVisible('tipoEval')).toBeTrue();
+      expect(component.isControlVisible('deptos')).toBeTrue();
+    });
+
+    it('should hide controls matching hide list when when-condition is met', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.componentRef.setInput('visibilityRules', visibilityRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'nivel', type: 'radial', label: 'Profesional' }, { checked: true });
+      fixture.detectChanges();
+
+      expect(component.isControlVisible('tipoEval')).toBeTrue();
+      expect(component.isControlVisible('deptos')).toBeFalse();
+    });
+
+    it('should show controls matching show list and hide others when when-condition changes', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.componentRef.setInput('visibilityRules', visibilityRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'nivel', type: 'radial', label: 'Preparatoria' }, { checked: true });
+      fixture.detectChanges();
+
+      expect(component.isControlVisible('deptos')).toBeTrue();
+      expect(component.isControlVisible('tipoEval')).toBeFalse();
+    });
+
+    it('should clear form value of a control when it is hidden', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.componentRef.setInput('visibilityRules', visibilityRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'tipoEval', type: 'radial', label: 'Parcial' }, { checked: true });
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'nivel', type: 'radial', label: 'Preparatoria' }, { checked: true });
+      fixture.detectChanges();
+
+      expect(component.filterForm.get('tipoEval')?.value).toBeFalsy();
+    });
+
+    it('should hide a section title when all its controls are hidden', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.componentRef.setInput('visibilityRules', visibilityRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'nivel', type: 'radial', label: 'Profesional' }, { checked: true });
+      fixture.detectChanges();
+
+      const deptosSection = baseControlTypes.find(ct =>
+        ct.control.some(c => c.name === 'deptos'),
+      )!;
+      expect(component.isSectionVisible(deptosSection)).toBeFalse();
+    });
+
+    it('should reset visibility when onReset is called', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', baseControlTypes);
+      fixture.componentRef.setInput('visibilityRules', visibilityRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'nivel', type: 'radial', label: 'Profesional' }, { checked: true });
+      fixture.detectChanges();
+
+      component.onReset();
+      fixture.detectChanges();
+
+      expect(component.isControlVisible('tipoEval')).toBeTrue();
+      expect(component.isControlVisible('deptos')).toBeTrue();
+    });
+  });
+
+  describe('Cascading Filters (optionRules)', () => {
+    const cascadeControlTypes: IBmbControlType[] = [
+      {
+        title: 'Campus',
+        control: [
+          { name: 'campus', type: 'radial', label: 'Monterrey' },
+          { name: 'campus', type: 'radial', label: 'Guadalajara' },
+        ],
+      },
+      {
+        title: 'Carrera',
+        control: [
+          {
+            name: 'carrera',
+            type: 'dropdown',
+            label: 'Carrera',
+            options: [],
+          },
+        ],
+      },
+    ];
+
+    const monterreyOptions = ['Ingeniería', 'Negocios', 'Medicina'];
+    const guadalajaraOptions = ['Arquitectura', 'Diseño'];
+
+    const optionRules: IBmbOptionRule[] = [
+      { when: { campus: 'Monterrey' }, target: 'carrera', options: monterreyOptions },
+      { when: { campus: 'Guadalajara' }, target: 'carrera', options: guadalajaraOptions },
+    ];
+
+    it('should return static options when no optionRules are provided', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', cascadeControlTypes);
+      fixture.detectChanges();
+
+      const carreraControl = cascadeControlTypes[1].control[0];
+      expect(component.getControlOptions(carreraControl)).toEqual([]);
+    });
+
+    it('should return dynamic options when when-condition is met', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', cascadeControlTypes);
+      fixture.componentRef.setInput('optionRules', optionRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'campus', type: 'radial', label: 'Monterrey' }, { checked: true });
+      fixture.detectChanges();
+
+      const carreraControl = cascadeControlTypes[1].control[0];
+      expect(component.getControlOptions(carreraControl)).toEqual(monterreyOptions);
+    });
+
+    it('should update dynamic options when source control changes', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', cascadeControlTypes);
+      fixture.componentRef.setInput('optionRules', optionRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'campus', type: 'radial', label: 'Monterrey' }, { checked: true });
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'campus', type: 'radial', label: 'Guadalajara' }, { checked: true });
+      fixture.detectChanges();
+
+      const carreraControl = cascadeControlTypes[1].control[0];
+      expect(component.getControlOptions(carreraControl)).toEqual(guadalajaraOptions);
+    });
+
+    it('should clear dependent dropdown value if current value is not in new options', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', cascadeControlTypes);
+      fixture.componentRef.setInput('optionRules', optionRules);
+      fixture.detectChanges();
+
+      component.controlChange({ name: 'campus', type: 'radial', label: 'Monterrey' }, { checked: true });
+      component.onValueChange('Ingeniería', 'carrera');
+      fixture.detectChanges();
+
+      expect(component.filterForm.get('carrera')?.value).toBe('Ingeniería');
+
+      component.controlChange({ name: 'campus', type: 'radial', label: 'Guadalajara' }, { checked: true });
+      fixture.detectChanges();
+
+      expect(component.filterForm.get('carrera')?.value).toBeFalsy();
+    });
   });
 });

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.ts
@@ -1,5 +1,7 @@
 import {
   Component,
+  computed,
+  effect,
   input,
   OnInit,
   ChangeDetectionStrategy,
@@ -17,7 +19,12 @@ import { BmbRadialComponent } from '../bmb-radial/bmb-radial.component';
 import { BmbCheckboxComponent } from '../bmb-checkbox/bmb-checkbox.component';
 import { IBmbNativeModal } from '../bmb-modal/bmb-modal.interface';
 import { BmbInputComponent } from '../bmb-input/bmb-input.component';
-import { IBmbControlType } from './bmb-filter-card.interface';
+import {
+  IBmbControlType,
+  IBmbOptionRule,
+  IBmbVisibilityRule,
+} from './bmb-filter-card.interface';
+import { IBmbDropdownItem } from '../bmb-dropdown/bmb-dropdown.component';
 import { BmbButtonDirective } from '../../directives/bmb-button/button.directive';
 import { BmbDropdownComponent } from '../bmb-dropdown/bmb-dropdown.component';
 import { BmbTagComponent } from '../bmb-tags/bmb-tags.component';
@@ -59,6 +66,9 @@ export class BmbFilterCardComponent implements OnInit {
   dropdownOptions = input<string[]>([]); // deprecated
   placeholderSearch = input<string>('');
 
+  visibilityRules = input<IBmbVisibilityRule[]>([]);
+  optionRules = input<IBmbOptionRule[]>([]);
+
   applyFilters = output<any>();
   resetFilters = output<void>();
 
@@ -69,9 +79,56 @@ export class BmbFilterCardComponent implements OnInit {
 
   modalId = signal<string | null>(null);
 
+  private filterValues = signal<Record<string, any>>({});
+
+  private readonly visibleControlIds = computed(() => {
+    const rules = this.visibilityRules();
+    if (!rules.length) return null;
+    const values = this.filterValues();
+    const map = new Map<string, boolean>();
+    for (const rule of rules) {
+      if (this.ruleMatches(rule.when, values)) {
+        rule.show?.forEach((id) => map.set(id, true));
+        rule.hide?.forEach((id) => map.set(id, false));
+      }
+    }
+    return map;
+  });
+
+  private readonly dynamicOptionsMap = computed(() => {
+    const rules = this.optionRules();
+    if (!rules.length) return new Map<string, string[] | IBmbDropdownItem[]>();
+    const values = this.filterValues();
+    const map = new Map<string, string[] | IBmbDropdownItem[]>();
+    for (const rule of rules) {
+      if (this.ruleMatches(rule.when, values)) {
+        map.set(rule.target, rule.options);
+      }
+    }
+    return map;
+  });
+
   @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
 
-  constructor(private modalService: BmbNativeModalService) {}
+  constructor(private modalService: BmbNativeModalService) {
+    effect(() => {
+      const visMap = this.visibleControlIds();
+      if (visMap) {
+        visMap.forEach((visible, name) => {
+          if (!visible) this.clearControl(name);
+        });
+      }
+
+      this.dynamicOptionsMap().forEach((options, name) => {
+        const current = this.filterForm.get(name)?.value;
+        if (!current) return;
+        const validValues = options.map((o) =>
+          typeof o === 'string' ? o : o.value,
+        );
+        if (!validValues.includes(current)) this.clearControl(name);
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.controlTypes().forEach((controlType) => {
@@ -132,6 +189,14 @@ export class BmbFilterCardComponent implements OnInit {
         }
       });
     });
+
+    const initial: Record<string, any> = {};
+    this.controlTypes().forEach((ct) =>
+      ct.control.forEach((c) => {
+        initial[c.name] = this.filterForm.get(c.name)?.value;
+      }),
+    );
+    this.filterValues.set(initial);
   }
 
   openModalComponent() {
@@ -165,6 +230,7 @@ export class BmbFilterCardComponent implements OnInit {
       switch (control.type) {
         case 'switch':
           formControl.setValue(event);
+          this.updateFilterValues(control.name, formControl.value);
           const switchValue = {
             ...this.storedValues[control.name],
             checked: event,
@@ -173,6 +239,7 @@ export class BmbFilterCardComponent implements OnInit {
           break;
         case 'checkbox':
           formControl.setValue(event.target.checked);
+          this.updateFilterValues(control.name, formControl.value);
           const checkboxValue = {
             ...this.storedValues[control.name],
             checked: event.target.checked,
@@ -181,15 +248,18 @@ export class BmbFilterCardComponent implements OnInit {
           break;
         case 'radial':
           formControl.setValue(control.label);
+          this.updateFilterValues(control.name, control.value ?? control.label);
           const radialValue = {
             ...this.storedValues[control.name],
             checked: event.checked,
             value: control.value ?? control.label,
+            label: control.label,
           };
           this.storedValues[control.name] = radialValue;
           break;
         case 'dropdown':
           formControl.setValue(event);
+          this.updateFilterValues(control.name, formControl.value);
           this.storedValues[control.name] = {
             ...this.storedValues[control.name],
             value: control.value ?? control.label,
@@ -198,6 +268,7 @@ export class BmbFilterCardComponent implements OnInit {
         default: //for the tag option or any other option that does not have an activated control
           const updatedValue = !this.storedValues[control.name]?.checked;
           formControl.setValue(updatedValue);
+          this.updateFilterValues(control.name, formControl.value);
           const elementValue = {
             ...this.storedValues[control.name],
             checked: updatedValue,
@@ -211,16 +282,20 @@ export class BmbFilterCardComponent implements OnInit {
   handleSubmit() {
     const formData: any = {};
     Object.keys(this.storedValues).forEach((key) => {
+      const stored = this.storedValues[key];
       if (
-        (this.storedValues[key].checked &&
-          (this.storedValues[key].type === 'checkbox' ||
-            this.storedValues[key].type === 'tag' ||
-            this.storedValues[key].type === 'radial' ||
-            this.storedValues[key].type === 'switch')) ||
-        (this.storedValues[key].value &&
-          this.storedValues[key].type === 'dropdown')
+        stored.checked &&
+        (stored.type === 'checkbox' ||
+          stored.type === 'tag' ||
+          stored.type === 'radial' ||
+          stored.type === 'switch')
       ) {
-        formData[key] = this.storedValues[key];
+        formData[key] = stored;
+      } else if (stored.type === 'dropdown') {
+        const currentValue = this.filterForm.get(key)?.value;
+        if (currentValue) {
+          formData[key] = { ...stored, value: currentValue };
+        }
       }
     });
     const globalSearchValue = this.filterForm.get('search')?.value;
@@ -233,7 +308,49 @@ export class BmbFilterCardComponent implements OnInit {
 
   onReset() {
     this.filterForm.reset();
+    this.filterValues.set({});
     this.resetFilters.emit();
+  }
+
+  private ruleMatches(
+    when: Record<string, any>,
+    values: Record<string, any>,
+  ): boolean {
+    return Object.entries(when).every(([k, v]) => values[k] === v);
+  }
+
+  private clearControl(name: string): void {
+    this.filterForm.get(name)?.reset();
+    if (this.storedValues[name]) {
+      this.storedValues[name] = {
+        ...this.storedValues[name],
+        checked: false,
+        value: '',
+      };
+    }
+  }
+
+  private updateFilterValues(name: string, value: any): void {
+    this.filterValues.update((vals) => ({ ...vals, [name]: value }));
+  }
+
+  isControlVisible(name: string): boolean {
+    const map = this.visibleControlIds();
+    if (!map) return true;
+    const visible = map.get(name);
+    return visible === undefined ? true : visible;
+  }
+
+  isSectionVisible(controlType: IBmbControlType): boolean {
+    const map = this.visibleControlIds();
+    if (!map) return true;
+    return controlType.control.some((c) => this.isControlVisible(c.name));
+  }
+
+  getControlOptions(
+    control: IBmbControlType['control'][number],
+  ): string[] | IBmbDropdownItem[] {
+    return this.dynamicOptionsMap().get(control.name) ?? control.options ?? [];
   }
 
   getFormControl(name: string): FormControl {
@@ -242,5 +359,9 @@ export class BmbFilterCardComponent implements OnInit {
 
   onValueChange(event: string, name: string) {
     this.filterForm.get(name)?.setValue(event);
+    this.updateFilterValues(name, event);
+    if (this.storedValues[name]) {
+      this.storedValues[name] = { ...this.storedValues[name], value: event };
+    }
   }
 }

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.interface.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.interface.ts
@@ -15,3 +15,15 @@ export interface IBmbControlType {
     isMultiSelect?: boolean;
   }[];
 }
+
+export interface IBmbVisibilityRule {
+  when: Record<string, any>;
+  show?: string[];
+  hide?: string[];
+}
+
+export interface IBmbOptionRule {
+  when: Record<string, any>;
+  target: string;
+  options: string[] | IBmbDropdownItem[];
+}

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.stories.ts
@@ -68,6 +68,46 @@ ${getBasicExampleBlock('BmbFilterCardComponent')}
     primaryBtnLabel: DBmbModalParamDesc.primaryBtnLabel,
     secondaryBtnLabel: DBmbModalParamDesc.secondaryBtnLabel,
     icon: DBmbButtonParamDesc.icon,
+    visibilityRules: {
+      control: { type: 'object' },
+      description: `
+Declares conditional visibility rules. Each rule specifies a \`when\` condition (a map of control name → expected value) and lists of control names to \`show\` or \`hide\` when the condition is met.
+
+When a dependent control is hidden, its form value is automatically cleared.
+
+\`\`\`ts
+visibilityRules: [
+  { when: { nivel: 'Profesional' }, show: ['tipoEval', 'escuelas'], hide: ['deptos'] },
+  { when: { nivel: 'Preparatoria' }, show: ['deptos'], hide: ['tipoEval', 'escuelas'] },
+]
+\`\`\`
+      `,
+      table: {
+        category: 'Conditional Filters',
+        type: { summary: 'IBmbVisibilityRule[]' },
+        defaultValue: { summary: '[]' },
+      },
+    },
+    optionRules: {
+      control: { type: 'object' },
+      description: `
+Declares cascading option rules. Each rule specifies a \`when\` condition and the new \`options\` to apply to the \`target\` dropdown when the condition is met.
+
+If the target dropdown's current value is not in the new options list, it is automatically cleared.
+
+\`\`\`ts
+optionRules: [
+  { when: { campus: 'Monterrey' }, target: 'carrera', options: ['Ingeniería', 'Negocios'] },
+  { when: { campus: 'Guadalajara' }, target: 'carrera', options: ['Arquitectura', 'Diseño'] },
+]
+\`\`\`
+      `,
+      table: {
+        category: 'Conditional Filters',
+        type: { summary: 'IBmbOptionRule[]' },
+        defaultValue: { summary: '[]' },
+      },
+    },
     placeholderSearch: {
       control: { type: 'text' },
       description: 'Sets the placeholder text for the search input.',
@@ -260,3 +300,475 @@ Data descriptions:
 type Story = StoryObj<typeof BmbFilterCardComponent>;
 
 export const Default: Story = {};
+
+export const ConditionalFilters = {
+  name: 'Conditional Filters (visibilityRules)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates **Conditional Filters** using \`visibilityRules\`.
+
+Select **Profesional** to show *Tipo de evaluación* and *Escuelas* while hiding *Departamentos (Prepa)*.
+Select **Preparatoria** to show *Departamentos (Prepa)* while hiding the other two.
+
+When a control is hidden, its previously selected value is cleared automatically.
+        `,
+      },
+    },
+  },
+  args: {
+    inLine: true,
+    showGlobalSearch: false,
+    modalTitle: 'Filtros',
+    primaryBtnLabel: 'Aplicar',
+    secondaryBtnLabel: 'Limpiar',
+    icon: 'tune',
+    controlTypes: [
+      {
+        title: 'Nivel',
+        control: [
+          {
+            name: 'nivel',
+            type: 'radial',
+            label: 'Profesional',
+            id: 'nivel-profesional',
+            value: 'Profesional',
+            checked: true,
+          },
+          {
+            name: 'nivel',
+            type: 'radial',
+            label: 'Preparatoria',
+            id: 'nivel-preparatoria',
+            value: 'Preparatoria',
+            checked: false,
+          },
+        ],
+      },
+      {
+        title: 'Tipo de evaluación',
+        control: [
+          {
+            name: 'tipoEval',
+            type: 'radial',
+            label: 'Parcial',
+            id: 'tipo-parcial',
+            value: 'Parcial',
+          },
+          {
+            name: 'tipoEval',
+            type: 'radial',
+            label: 'Final',
+            id: 'tipo-final',
+            value: 'Final',
+          },
+        ],
+      },
+      {
+        title: 'Estatus',
+        control: [
+          {
+            name: 'estatus',
+            type: 'radial',
+            label: 'Activo',
+            id: 'estatus-activo',
+            value: 'Activo',
+          },
+          {
+            name: 'estatus',
+            type: 'radial',
+            label: 'Inactivo',
+            id: 'estatus-inactivo',
+            value: 'Inactivo',
+          },
+        ],
+      },
+      {
+        title: 'Escuelas (Profesional)',
+        control: [
+          { name: 'escuelaIngenieria', type: 'tag', label: 'Ingeniería' },
+          { name: 'escuelaMedicina', type: 'tag', label: 'Medicina' },
+          { name: 'escuelaNegocios', type: 'tag', label: 'Negocios' },
+        ],
+      },
+      {
+        title: 'Departamentos (Prepa)',
+        control: [
+          { name: 'deptoMatematicas', type: 'tag', label: 'Matemáticas' },
+          { name: 'deptoCiencias', type: 'tag', label: 'Ciencias' },
+        ],
+      },
+    ],
+    visibilityRules: [
+      {
+        when: { nivel: 'Profesional' },
+        show: [
+          'tipoEval',
+          'escuelaIngenieria',
+          'escuelaMedicina',
+          'escuelaNegocios',
+        ],
+        hide: ['deptoMatematicas', 'deptoCiencias'],
+      },
+      {
+        when: { nivel: 'Preparatoria' },
+        show: ['deptoMatematicas', 'deptoCiencias'],
+        hide: [
+          'tipoEval',
+          'escuelaIngenieria',
+          'escuelaMedicina',
+          'escuelaNegocios',
+        ],
+      },
+    ],
+    optionRules: [],
+    showDropdown: true,
+  },
+};
+
+export const CascadingFilters = {
+  name: 'Cascading Filters (optionRules)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates **Cascading Filters** using \`optionRules\`.
+
+Select a **Campus** to dynamically update the available options in the **Carrera** dropdown.
+If the previously selected carrera is no longer valid after the campus changes, it is cleared automatically.
+        `,
+      },
+    },
+  },
+  args: {
+    inLine: true,
+    showGlobalSearch: false,
+    modalTitle: 'Filtros',
+    primaryBtnLabel: 'Aplicar',
+    secondaryBtnLabel: 'Limpiar',
+    icon: 'tune',
+    controlTypes: [
+      {
+        title: 'Campus',
+        control: [
+          {
+            name: 'campus',
+            type: 'radial',
+            label: 'Monterrey',
+            id: 'campus-mty',
+            value: 'Monterrey',
+          },
+          {
+            name: 'campus',
+            type: 'radial',
+            label: 'Guadalajara',
+            id: 'campus-gdl',
+            value: 'Guadalajara',
+          },
+          {
+            name: 'campus',
+            type: 'radial',
+            label: 'Ciudad de México',
+            id: 'campus-cdmx',
+            value: 'Ciudad de México',
+          },
+        ],
+      },
+      {
+        title: 'Carrera',
+        control: [
+          {
+            name: 'carrera',
+            type: 'dropdown',
+            label: 'Carrera',
+            placeholder: 'Selecciona una carrera',
+            options: [],
+          },
+        ],
+      },
+    ],
+    visibilityRules: [],
+    optionRules: [
+      {
+        when: { campus: 'Monterrey' },
+        target: 'carrera',
+        options: ['Ingeniería', 'Negocios', 'Medicina', 'Arquitectura'],
+      },
+      {
+        when: { campus: 'Guadalajara' },
+        target: 'carrera',
+        options: ['Arquitectura', 'Diseño', 'Arte'],
+      },
+      {
+        when: { campus: 'Ciudad de México' },
+        target: 'carrera',
+        options: ['Derecho', 'Economía', 'Ciencias Sociales'],
+      },
+    ],
+  },
+};
+
+export const CascadingFiltersWithObjects = {
+  name: 'Cascading Filters with IBmbDropdownItem (name ≠ value)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates **Cascading Filters** using \`IBmbDropdownItem[]\` objects in \`optionRules\`.
+
+Each option has a **\`name\`** (display label) and a **\`value\`** (identifier emitted on apply).
+This is useful when you need to show a human-readable label but send a technical identifier to the backend.
+
+The emitted \`applyFilters\` event will contain the **\`value\`** field (e.g. \`'ing-sistemas'\`), not the display name.
+        `,
+      },
+    },
+  },
+  args: {
+    inLine: true,
+    showGlobalSearch: false,
+    modalTitle: 'Filtros',
+    primaryBtnLabel: 'Aplicar',
+    secondaryBtnLabel: 'Limpiar',
+    icon: 'tune',
+    controlTypes: [
+      {
+        title: 'Campus',
+        control: [
+          {
+            name: 'campusObj',
+            type: 'radial',
+            label: 'Monterrey',
+            id: 'campusobj-mty',
+            value: 'MTY',
+          },
+          {
+            name: 'campusObj',
+            type: 'radial',
+            label: 'Guadalajara',
+            id: 'campusobj-gdl',
+            value: 'GDL',
+          },
+        ],
+      },
+      {
+        title: 'Carrera',
+        control: [
+          {
+            name: 'carreraObj',
+            type: 'dropdown',
+            label: 'Carrera',
+            placeholder: 'Selecciona una carrera',
+            options: [],
+          },
+        ],
+      },
+    ],
+    visibilityRules: [],
+    optionRules: [
+      {
+        when: { campusObj: 'MTY' },
+        target: 'carreraObj',
+        options: [
+          { name: 'Ingeniería en Sistemas', value: 'ing-sistemas' },
+          { name: 'Ingeniería en Mecatrónica', value: 'ing-mecatronica' },
+          { name: 'Negocios Internacionales', value: 'neg-int' },
+        ],
+      },
+      {
+        when: { campusObj: 'GDL' },
+        target: 'carreraObj',
+        options: [
+          { name: 'Arquitectura y Diseño', value: 'arq-dis' },
+          { name: 'Diseño Industrial', value: 'dis-ind' },
+        ],
+      },
+    ],
+  },
+};
+
+export const CombinedRules = {
+  name: 'Combined Rules (visibilityRules + optionRules)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates **simultaneous use of \`visibilityRules\` and \`optionRules\`** (section 2.4 of the technical spec).
+
+Both inputs are independent and coexist on the same component instance.
+
+- **\`visibilityRules\`** controls whether the *Departamento* dropdown is shown or hidden.
+- **\`optionRules\`** controls which options the dropdown exposes when it is visible.
+
+Select **Profesional** → the *Departamento* dropdown appears with professional departments.
+Select **Preparatoria** → the *Departamento* dropdown is hidden and its previously selected value is cleared automatically.
+        `,
+      },
+    },
+  },
+  args: {
+    inLine: true,
+    showGlobalSearch: false,
+    modalTitle: 'Filtros',
+    primaryBtnLabel: 'Aplicar',
+    secondaryBtnLabel: 'Limpiar',
+    icon: 'tune',
+    controlTypes: [
+      {
+        title: 'Nivel',
+        control: [
+          {
+            name: 'nivelCombo',
+            type: 'radial',
+            label: 'Profesional',
+            id: 'combo-nivel-pro',
+            value: 'PRO',
+            checked: true,
+          },
+          {
+            name: 'nivelCombo',
+            type: 'radial',
+            label: 'Preparatoria',
+            id: 'combo-nivel-prep',
+            value: 'PREP',
+          },
+        ],
+      },
+      {
+        title: 'Departamento',
+        control: [
+          {
+            name: 'deptoCombo',
+            type: 'dropdown',
+            label: 'Departamento',
+            placeholder: 'Selecciona un departamento',
+            options: [],
+          },
+        ],
+      },
+    ],
+    visibilityRules: [
+      { when: { nivelCombo: 'PRO' }, show: ['deptoCombo'] },
+      { when: { nivelCombo: 'PREP' }, hide: ['deptoCombo'] },
+    ],
+    optionRules: [
+      {
+        when: { nivelCombo: 'PRO' },
+        target: 'deptoCombo',
+        options: ['Ingeniería', 'Negocios', 'Medicina'],
+      },
+      {
+        when: { nivelCombo: 'PREP' },
+        target: 'deptoCombo',
+        options: ['Matemáticas', 'Ciencias', 'Historia'],
+      },
+    ],
+  },
+};
+
+export const MultiFieldCondition = {
+  name: 'Multi-field AND Condition (optionRules)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates **\`optionRules\` with a multi-field \`when\` condition** (section 2.5 of the technical spec).
+
+A rule applies only when **all fields in \`when\` match simultaneously** (logical AND).
+The *Carrera* dropdown remains empty until **both** Campus and Nivel are selected.
+
+| Campus | Nivel | Opciones disponibles |
+|---|---|---|
+| Monterrey | Profesional | Ingeniería, Medicina, Negocios |
+| Monterrey | Preparatoria | Preparatoria Tec Monterrey |
+| Guadalajara | Profesional | Arquitectura, Diseño |
+| Guadalajara | Preparatoria | Preparatoria Tec Guadalajara |
+        `,
+      },
+    },
+  },
+  args: {
+    inLine: true,
+    showGlobalSearch: false,
+    modalTitle: 'Filtros',
+    primaryBtnLabel: 'Aplicar',
+    secondaryBtnLabel: 'Limpiar',
+    icon: 'tune',
+    controlTypes: [
+      {
+        title: 'Campus',
+        control: [
+          {
+            name: 'campusAnd',
+            type: 'radial',
+            label: 'Monterrey',
+            id: 'and-campus-mty',
+            value: 'MTY',
+          },
+          {
+            name: 'campusAnd',
+            type: 'radial',
+            label: 'Guadalajara',
+            id: 'and-campus-gdl',
+            value: 'GDL',
+          },
+        ],
+      },
+      {
+        title: 'Nivel',
+        control: [
+          {
+            name: 'nivelAnd',
+            type: 'radial',
+            label: 'Profesional',
+            id: 'and-nivel-pro',
+            value: 'PRO',
+          },
+          {
+            name: 'nivelAnd',
+            type: 'radial',
+            label: 'Preparatoria',
+            id: 'and-nivel-prep',
+            value: 'PREP',
+          },
+        ],
+      },
+      {
+        title: 'Carrera',
+        control: [
+          {
+            name: 'carreraAnd',
+            type: 'dropdown',
+            label: 'Carrera',
+            placeholder: 'Selecciona campus y nivel primero',
+            options: [],
+          },
+        ],
+      },
+    ],
+    visibilityRules: [],
+    optionRules: [
+      {
+        when: { campusAnd: 'MTY', nivelAnd: 'PRO' },
+        target: 'carreraAnd',
+        options: ['Ingeniería', 'Medicina', 'Negocios'],
+      },
+      {
+        when: { campusAnd: 'MTY', nivelAnd: 'PREP' },
+        target: 'carreraAnd',
+        options: ['Preparatoria Tec Monterrey'],
+      },
+      {
+        when: { campusAnd: 'GDL', nivelAnd: 'PRO' },
+        target: 'carreraAnd',
+        options: ['Arquitectura', 'Diseño'],
+      },
+      {
+        when: { campusAnd: 'GDL', nivelAnd: 'PREP' },
+        target: 'carreraAnd',
+        options: ['Preparatoria Tec Guadalajara'],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
[DS01-XXXX](https://tecdemonterrey.atlassian.net/browse/DS01-XXXX) - Conditional & Cascading Filters for bmb-filter-card Issues#979

# Changes proposed in this PR: 💻

# Justificación Técnica: Conditional & Cascading Filters en BmbFilterCardComponent

# 1. Descripción funcional

Se añadieron dos nuevos inputs al componente:

| Input           | Tipo                 | Propósito                                                            |
| --------------- | -------------------- | -------------------------------------------------------------------- |
| visibilityRules | IBmbVisibilityRule[] | Muestra u oculta controles según el valor de otro control            |
| optionRules     | IBmbOptionRule[]     | Reemplaza las opciones de un dropdown según el valor de otro control |

Ambos son opcionales y con valor por defecto `[]`, garantizando retro-compatibilidad total con todos los usos existentes del componente.

---

# 2. Comportamientos soportados y cómo poblarlos

| Sección del documento                    | Story en Storybook                                                     |
| ---------------------------------------- | ---------------------------------------------------------------------- |
| 2.1 — visibilityRules (show/hide)        | ConditionalFilters — Conditional Filters (visibilityRules)             |
| 2.2 — optionRules con string[]           | CascadingFilters — Cascading Filters (optionRules)                     |
| 2.3 — optionRules con IBmbDropdownItem[] | CascadingFiltersWithObjects — Cascading Filters with IBmbDropdownItem  |
| 2.4 — Ambas reglas simultáneas           | CombinedRules — Combined Rules (visibilityRules + optionRules) ✨ nuevo |
| 2.5 — Condición AND multi-campo          | MultiFieldCondition — Multi-field AND Condition (optionRules) ✨ nuevo  |

### Puntos de diseño aplicados en las stories nuevas:

* Nombres de control únicos (`nivelCombo`, `deptoCombo`, `campusAnd`, `nivelAnd`, `carreraAnd`) — evita colisiones de grupos HTML radio entre stories en la misma página de docs.
* IDs únicos en cada radial (`combo-nivel-pro`, `and-campus-mty`, etc.) — requerimiento HTML para `<input type="radio">`.
* CombinedRules arranca con `nivelCombo: checked: true` en Profesional — el dropdown Departamento aparece visible desde el primer render, demostrando que `checked: true` desencadena la evaluación inicial de ambas reglas.
* MultiFieldCondition usa `placeholder: 'Selecciona campus y nivel primero'` — comunica explícitamente al usuario que el dropdown requiere dos selecciones previas para poblarse.

---

## 2.1 Filtros condicionales — visibilityRules

Muestra u oculta grupos de controles en función del valor seleccionado en otro control. Cuando un control se oculta, su valor se limpia automáticamente.

### Template

```html
<bmb-filter-card
  [inLine]="true"
  [controlTypes]="controlTypes"
  [visibilityRules]="visibilityRules"
  primaryBtnLabel="Aplicar"
  secondaryBtnLabel="Limpiar"
/>
```

### Componente

```ts
controlTypes: IBmbControlType[] = [
  {
    title: 'Nivel',
    control: [
      { name: 'nivel', type: 'radial', label: 'Profesional',  id: 'nivel-profesional', value: 'Profesional', checked: true },
      { name: 'nivel', type: 'radial', label: 'Preparatoria', id: 'nivel-preparatoria', value: 'Preparatoria' },
    ],
  },
  {
    title: 'Tipo de evaluación',
    control: [
      { name: 'tipoEval', type: 'radial', label: 'Parcial', id: 'tipo-parcial', value: 'Parcial' },
      { name: 'tipoEval', type: 'radial', label: 'Final',   id: 'tipo-final',   value: 'Final'   },
    ],
  },
  {
    title: 'Escuelas (Profesional)',
    control: [
      { name: 'escuelaIngenieria', type: 'tag', label: 'Ingeniería' },
      { name: 'escuelaMedicina',   type: 'tag', label: 'Medicina'   },
      { name: 'escuelaNegocios',   type: 'tag', label: 'Negocios'   },
    ],
  },
  {
    title: 'Departamentos (Prepa)',
    control: [
      { name: 'deptoMatematicas', type: 'tag', label: 'Matemáticas' },
      { name: 'deptoCiencias',    type: 'tag', label: 'Ciencias'    },
    ],
  },
];

visibilityRules: IBmbVisibilityRule[] = [
  {
    when: { nivel: 'Profesional' },
    show: ['tipoEval', 'escuelaIngenieria', 'escuelaMedicina', 'escuelaNegocios'],
    hide: ['deptoMatematicas', 'deptoCiencias'],
  },
  {
    when: { nivel: 'Preparatoria' },
    show: ['deptoMatematicas', 'deptoCiencias'],
    hide: ['tipoEval', 'escuelaIngenieria', 'escuelaMedicina', 'escuelaNegocios'],
  },
];
```

### Comportamiento resultante

| Selección                      | Visible                      | Oculto y limpiado            |
| ------------------------------ | ---------------------------- | ---------------------------- |
| Profesional (pre-seleccionado) | Tipo de evaluación, Escuelas | Departamentos (Prepa)        |
| Preparatoria                   | Departamentos (Prepa)        | Tipo de evaluación, Escuelas |

**Nota:** `checked: true` en el radial *Profesional* establece la selección inicial al cargar el componente. Las reglas de visibilidad se evalúan inmediatamente con ese valor, por lo que el estado correcto se muestra desde el primer render sin que el usuario necesite interactuar.

---

## 2.2 Filtros en cascada con opciones de texto — optionRules + string[]

Reemplaza las opciones de un dropdown dependiendo del valor seleccionado en otro control. El dropdown comienza vacío (options: []) y se puebla dinámicamente.

**Template**:

```html
<bmb-filter-card
  [inLine]="true"
  [controlTypes]="controlTypes"
  [optionRules]="optionRules"
  primaryBtnLabel="Aplicar"
  secondaryBtnLabel="Limpiar"
/>
```

**Componente:**
```ts
controlTypes: IBmbControlType[] = [
  {
    title: 'Campus',
    control: [
      { name: 'campus', type: 'radial', label: 'Monterrey',       id: 'campus-mty',  value: 'Monterrey'       },
      { name: 'campus', type: 'radial', label: 'Guadalajara',     id: 'campus-gdl',  value: 'Guadalajara'     },
      { name: 'campus', type: 'radial', label: 'Ciudad de México', id: 'campus-cdmx', value: 'Ciudad de México' },
    ],
  },
  {
    title: 'Carrera',
    control: [
      {
        name: 'carrera',
        type: 'dropdown',
        label: 'Carrera',
        placeholder: 'Selecciona una carrera',
        options: [],   // vacío: se puebla por optionRules
      },
    ],
  },
];

optionRules: IBmbOptionRule[] = [
  { when: { campus: 'Monterrey'       }, target: 'carrera', options: ['Ingeniería', 'Negocios', 'Medicina', 'Arquitectura'] },
  { when: { campus: 'Guadalajara'     }, target: 'carrera', options: ['Arquitectura', 'Diseño', 'Arte']                    },
  { when: { campus: 'Ciudad de México' }, target: 'carrera', options: ['Derecho', 'Economía', 'Ciencias Sociales']          },
];
```

**Comportamiento resultante:**

| Campus seleccionado	| Opciones disponibles en Carrera |
| --------------------- | ------------------------------- |
| (ninguno)	| Dropdown vacío, muestra placeholder |
| Monterrey	| Ingeniería, Negocios, Medicina, Arquitectura | 
| Guadalajara	| Arquitectura, Diseño, Arte
| Ciudad de México	| Derecho, Economía, Ciencias Sociales

**Nota clave**: el campo `value` del radial (ej. `'Monterrey'`) es el que debe coincidir con la clave `when` de la regla, **no** el campo `label`. Esta separación entre valor semántico y etiqueta de presentación permite que el label sea traducible o cambie sin afectar la evaluación de las reglas.

---

## 2.3 Filtros en cascada con objetos `IBmbDropdownItem` — `optionRules` + `IBmbDropdownItem[]`
Cuando el label que se muestra al usuario es distinto al identificador que se envía al backend, se usa IBmbDropdownItem (name = texto visible, value = identificador técnico).

**Componente:**

```ts
controlTypes: IBmbControlType[] = [
  {
    title: 'Campus',
    control: [
      { name: 'campusObj', type: 'radial', label: 'Monterrey',   id: 'campusobj-mty', value: 'MTY' },
      { name: 'campusObj', type: 'radial', label: 'Guadalajara', id: 'campusobj-gdl', value: 'GDL' },
    ],
  },
  {
    title: 'Carrera',
    control: [
      {
        name: 'carreraObj',
        type: 'dropdown',
        label: 'Carrera',
        placeholder: 'Selecciona una carrera',
        options: [],
      },
    ],
  },
];

optionRules: IBmbOptionRule[] = [
  {
    when: { campusObj: 'MTY' },   // evalúa contra el value del radial, no el label
    target: 'carreraObj',
    options: [
      { name: 'Ingeniería en Sistemas',   value: 'ing-sistemas'    },
      { name: 'Ingeniería en Mecatrónica', value: 'ing-mecatronica' },
      { name: 'Negocios Internacionales', value: 'neg-int'         },
    ],
  },
  {
    when: { campusObj: 'GDL' },
    target: 'carreraObj',
    options: [
      { name: 'Arquitectura y Diseño', value: 'arq-dis' },
      { name: 'Diseño Industrial',     value: 'dis-ind' },
    ],
  },
];
```

**Comportamiento en `applyFilters`:**

```
// Usuario selecciona Monterrey → Ingeniería en Sistemas → Aplicar
{
  campusObj: { value: 'MTY', label: 'Monterrey', ... },
  carreraObj: { value: 'ing-sistemas', ... }   // ← value técnico, no el name visible
}
```

**El output `applyFilters` siempre emite el `value` técnico**, nunca el `name` de presentación. Esto permite que el backend reciba identificadores estables independientemente de los cambios en las etiquetas de la UI.

---

## 2.4 Combinación de ambas reglas — visibilityRules + optionRules simultáneos
Ambos inputs son independientes y pueden coexistir. Un caso de uso real: mostrar u ocultar un dropdown Y cambiar sus opciones al mismo tiempo.

```ts
controlTypes: IBmbControlType[] = [
  {
    title: 'Nivel',
    control: [
      { name: 'nivel', type: 'radial', label: 'Profesional',  id: 'nivel-pro',  value: 'PRO', checked: true },
      { name: 'nivel', type: 'radial', label: 'Preparatoria', id: 'nivel-prep', value: 'PREP' },
    ],
  },
  {
    title: 'Departamento',
    control: [
      { name: 'depto', type: 'dropdown', label: 'Departamento', placeholder: 'Selecciona', options: [] },
    ],
  },
];

visibilityRules: IBmbVisibilityRule[] = [
  { when: { nivel: 'PRO'  }, show: ['depto'] },
  { when: { nivel: 'PREP' }, hide: ['depto'] },
];

optionRules: IBmbOptionRule[] = [
  { when: { nivel: 'PRO'  }, target: 'depto', options: ['Ingeniería', 'Negocios', 'Medicina'] },
  { when: { nivel: 'PREP' }, target: 'depto', options: ['Matemáticas', 'Ciencias', 'Historia'] },
];
```

Cuando el usuario selecciona `Preparatoria`, el dropdown `Departamento` se oculta y su selección previa (si era de opciones de Profesional) se limpia automáticamente. Al volver a `Profesional`, el dropdown reaparece con las opciones correctas y sin valor residual.

---

## 2.5 Reglas con condición multi-campo (AND lógico)
El objeto `when` soporta múltiples claves. La regla aplica solo si **todas** las condiciones se cumplen simultáneamente:

```ts
optionRules: IBmbOptionRule[] = [
  {
    when: { campus: 'MTY', nivel: 'PRO' },   // AND: campus=MTY Y nivel=PRO
    target: 'carrera',
    options: ['Ingeniería', 'Medicina', 'Negocios'],
  },
  {
    when: { campus: 'MTY', nivel: 'PREP' },  // AND: campus=MTY Y nivel=PREP
    target: 'carrera',
    options: ['Preparatoria Tec'],
  },
];
```

---

# 3. Consideraciones al configurar los controles

| Regla                                         | Motivo                                    |
| --------------------------------------------- | ----------------------------------------- |
| El campo `name` de cada control es la clave que se usa en `when`                   | 	La evaluación es `filterValues[key] === value`, donde `key` es el `name` |
| Para radiales, el campo `value` (no `label`) debe coincidir con `when`               | `filterValues` almacena el `value` semántico, no el texto visible |
| Los dropdowns que serán poblados por `optionRules` deben iniciar con `options: []` | Señal explícita de que las opciones son controladas por reglas, no estáticas |
| Los `id` de los radiales deben ser únicos en toda la página                      | HTML agrupa `<input type="radio">` por el atributo `name`; IDs duplicados crean conflictos de estado entre instancias del componente en la misma página |
| `checked: true` en un radial establece la selección inicial                      | Las reglas se evalúan con ese valor desde el primer render; no se requiere interacción del usuario para el estado inicial correcto |

---

# 4. Decisiones de diseño

## 4.1 Enfoque declarativo basado en reglas (data-driven)

Ambos inputs reciben `arreglos de reglas` como mecanismo de configuración, en lugar de delegar el comportamiento a lógica imperativa dispersa en el consumidor. Este enfoque corresponde a un patrón `Rule-Based / Data-Driven`, ampliamente utilizado en librerías de formularios y componentes dinámicos, porque permite centralizar condiciones, reducir acoplamiento y mantener la lógica de UI cerca del componente que la ejecuta.

Este tipo de diseño es consistente con enfoques declarativos presentes en el ecosistema:

- **Angular Formly** permite definir comportamiento dinámico mediante expresiones declarativas (`expressions`, antes `hideExpression` / `expressionProperties`) para mostrar, ocultar o modificar propiedades de un campo en función del estado del modelo.
- **React Hook Form** no expone nativamente un esquema de `arreglo de reglas`, pero sí favorece un enfoque declarativo mediante `watch` / `useWatch` y renderizado condicional basado en el estado del formulario.
- **Angular Reactive Forms** también promueve composición declarativa de comportamiento mediante validadores y reglas asociadas a controles o grupos, aunque técnicamente estos validadores se implementan como funciones.

Bajo este enfoque, el componente conserva la responsabilidad sobre su estado derivado y sus transiciones internas. En cambio, una alternativa más imperativa —por ejemplo, exponer callbacks para que el consumidor reconstruya manualmente `controlTypes`, o exigir que escuche eventos para mutar estado externo— incrementa el acoplamiento, dispersa la lógica de decisión fuera del componente y favorece duplicación de comportamiento entre implementaciones.

---

## 4.2 Señal privada `filterValues: signal<Record<string, any>>`

```ts
private filterValues = signal<Record<string, any>>({});
```

`filterValues` es el **origen único de verdad** para el estado semántico de los controles. Es **privada** porque:

1. Separación de responsabilidades con filterForm: filterForm almacena valores de presentación (labels para radiales, strings para inputs). filterValues almacena los valores semánticos usados para evaluar reglas (el campo value de un radial, no su label). Son dos representaciones del mismo estado con propósitos distintos.
2. Propagación reactiva automática: cualquier computed() que dependa de ella se recalcula automáticamente sin Subject, BehaviorSubject ni gestión manual de suscripciones.
3. Encapsulamiento: el consumidor no tiene acceso directo a filterValues; recibe el resultado final vía applyFilters.

---

## 4.3 computed() para estado derivado: visibleControlIds y dynamicOptionsMap

```ts
private readonly visibleControlIds = computed(() => { ... });
private readonly dynamicOptionsMap = computed(() => { ... });
```

Propiedades que hacen correcto el uso de computed() aquí:
* Lazy evaluation: el recálculo ocurre solo cuando algo lee la señal Y alguna dependencia cambió.
* Memoización automática: si filterValues no cambió, devuelve el mismo resultado sin re-ejecutarse.
* Grafo reactivo explícito: Angular construye automáticamente la cadena filterValues → dynamicOptionsMap → getControlOptions → template.

Ambos computados devuelven un `Map<string, V>` para garantizar lookup en **O(1)** desde el template, en lugar de filtrar un array en cada ciclo de change detection.

---

## 4.4 `effect()` para side effects: limpieza de valores obsoletos

```ts
effect(() => {
  // limpieza automática
});
```

`effect()` es correcto aquí porque `filterForm.valueChanges` solo dispara cuando el formulario cambia desde dentro, no cuando cambian las reglas de visibilidad o de opciones (que son inputs externos).

---

## 4.5 `ruleMatches()`: predicado puro de evaluación

```ts
private ruleMatches(when: Record<string, any>, values: Record<string, any>): boolean {
  return Object.entries(when).every(([k, v]) => values[k] === v);
}
```

Implementa **conjunción lógica AND** sobre el mapa `when`: todos los pares `clave: valor` deben estar presentes e iguales en `values`. Es equivalente a una cláusula SQL `WHERE campo1 = val1 AND campo2 = val2`. Al ser una **función pura** (sin side effects, resultado determinístico) es trivialmente testeable.

---

# 5. Alternativas consideradas
## A) Emitir un output `filterChange` y dejar la lógica al consumidor
Requeriría que cada implementación del `filter-card` replique la lógica de visibilidad y opciones dinámicas. Viola el principio **DRY** y desplaza la complejidad al consumidor. No es viable para un componente de librería de diseño.

## B) Añadir métodos imperativos `showControl(name)` / `hideControl(name)` en el componente
Rompería `ChangeDetectionStrategy.OnPush` (los métodos mutar estado sin señales no disparan re-renders), expondría API pública adicional que tendría que mantenerse para siempre, y obligaría al consumidor a sincronizar el estado manualmente.

## C) Hacer `filterValues` pública y dejar que el consumidor la modifique
Rompería el encapsulamiento: la señal `filterValues` no es un contrato público del componente, es un detalle de implementación. Exponer señales internas crea acoplamiento que imposibilita refactors futuros.

## D) Calcular visibilidad y opciones directamente en el template con expresiones inline
Calcular `visibilityRules().find(r => ruleMatches(r.when, filterValues()))?.show?.includes(name)` en cada `@if` del template es:
- Rendimiento O(n×m) en cada ciclo de change detection
- Ilegible y difícil de mantener
- No memoizable (sin `computed`)

---

# 6. Angular Signals API

| Construcción | Uso          | Alternativa previa |
| ------------ | ------------ | ------------------ |
| `signal()`     | `filterValues` — estado mutable local	| `BehaviorSubject<Record<string,any>>`    |
| `computed()`   | `visibleControlIds`, `dynamicOptionsMap`	| `combineLatest + map + shareReplay`      |
| `effect()`     | Limpieza de valores obsoletos	| `valueChanges.subscribe + takeUntilDestroyed`    |
| `input()`      | `visibilityRules`, `optionRules`	| `@Input()` con `ngOnChanges`        |

La combinación `signal → computed → effect` es la [arquitectura de flujo de datos recomendada en Angular](https://angular.dev/guide/signals#reading-signals-in-templates) para componentes con estado derivado:

```
[Señal de entrada]
    filterValues (signal)
         │
         ├──► visibleControlIds (computed) ──► isControlVisible() ──► @if en template
         │
         └──► dynamicOptionsMap (computed) ──► getControlOptions() ──► [options] en template
                      │
                      └──► effect() ──► clearControl() [side effect]
```

Este es el mismo grafo reactivo unidireccional (unidirectional data flow) que prescribe la guía oficial, y que evita ciclos, condiciones de carrera y memoria de suscripciones colgadas.

---

# 7. Retro-compatibilidad garantizada

* Sin reglas → comportamiento original
* `visibleControlIds()` → `true`
* `dynamicOptionsMap()` → opciones originales
* `effect()` → no ejecuta cambios

---

# 5. Resumen
La implementación de Conditional & Cascading Filters respeta los principios fundamentales del diseño de componentes en librerías de UI y de la arquitectura de Angular:
1. Declarativo sobre imperativo: las reglas son datos, no código. El consumidor configura, el componente ejecuta
2. Single source of truth: filterValues es el único estado que alimenta todo el comportamiento reactivo.
3. Grafo reactivo explícito: signal → computed → effect define claramente qué depende de qué.
4. Retro-compatibilidad: sin visibilityRules ni optionRules, el componente funciona exactamente igual que antes.
5. Zero infraestructura de suscripciones: no hay subscribe, unsubscribe, takeUntilDestroyed ni async pipe adicionales.


## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

No hay cambios a nivel visual, más bien todo fue a nivel interno

## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit test before submitting.
- [x] My code resolved all of the task's acceptance criteria.
