### PR TITLE
fix(component/dropdown): se modificó la validación de tamaño de archi…

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  computed,
   input,
   model,
   OnChanges,

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
@@ -91,7 +91,6 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   newFile = output<File | File[]>();
   fileRemoved = output<string>();
 
-  // fileDataList: FileData[] = computed(() => []);
   fileDataList: FileData[] = [];
   isControlNull: boolean = false;
 
@@ -360,7 +359,6 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
 
   protected handleFileSelected(event: Event) {
     const _input = event.target as HTMLInputElement;
-    console.info('handleFileSelected', _input);
 
     if (_input.files?.[0]) {
       const files = _input.files;

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   input,
   model,
   OnChanges,
@@ -90,6 +91,7 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   newFile = output<File | File[]>();
   fileRemoved = output<string>();
 
+  // fileDataList: FileData[] = computed(() => []);
   fileDataList: FileData[] = [];
   isControlNull: boolean = false;
 
@@ -158,11 +160,11 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
           ).concat('* ')
         : ''
     }${
-      this.isFormatErrorFiles()
+      this.isSizeErrorFiles()
         ? (
             this.errorMessageSize() ||
             this.translationService.translate('dropzone.error_message_size')
-          ).concat('MB*')
+          ).concat(' MB*')
         : ''
     }`;
   }
@@ -358,6 +360,7 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
 
   protected handleFileSelected(event: Event) {
     const _input = event.target as HTMLInputElement;
+    console.info('handleFileSelected', _input);
 
     if (_input.files?.[0]) {
       const files = _input.files;


### PR DESCRIPTION
[DS01-3892](https://tecdemonterrey.atlassian.net/browse/DS01-3892) - [GH-tec-design-system-ng-1011] Dropzone - When I upload a file larger than the allowed size, it does not show an error.

## Changes proposed in this PR: 💻

- fix(component/dropdown): se modificó la validación de tamaño de archivo para mostrar el mensaje de error correcto.


## Visuals 🎴

<img width="1879" height="540" alt="image" src="https://github.com/user-attachments/assets/09d6ebfe-6628-40b8-a89a-07e017876bc0" />


## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit test before submitting.
- [x] My code resolved all of the task's acceptance criteria.
