### PR TITLE
 [GH-tec-design-system-ng-1133] Permitir personalizar el ícono del componente bmb-dropdown-menu

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.html
@@ -1,7 +1,7 @@
 <section class="bmb_dropdown-menu" #contentDiv>
   <bmb-action-icon
     class="bmb_dropdown-menu-button"
-    icon="more_vert"
+    [icon]="icon()"
     [iconSize]="24"
     (buttonClick)="openDropdown()"
     [alt]="'dropdown_menu.open_menu' | translate"

--- a/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.ts
@@ -14,6 +14,8 @@ import { IDropdownItem } from '../../types';
 import { BmbProjectionContentService } from '../../services/projection/projection.service';
 import { TranslatePipe } from '../../pipes/translations';
 
+export type IBmbDropdownMenuIcon = 'more_vert' | 'more_horiz';
+
 @Component({
   selector: 'bmb-dropdown-menu',
   standalone: true,
@@ -26,7 +28,7 @@ import { TranslatePipe } from '../../pipes/translations';
 export class BmbDropdownMenuComponent {
   items = input<IDropdownItem[]>([]);
 
-  icon = input<string>('more_vert');
+  icon = input<IBmbDropdownMenuIcon>('more_vert');
 
   clickedItem = output<IDropdownItem>();
   contentID = signal<string>('');

--- a/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.component.ts
@@ -26,6 +26,8 @@ import { TranslatePipe } from '../../pipes/translations';
 export class BmbDropdownMenuComponent {
   items = input<IDropdownItem[]>([]);
 
+  icon = input<string>('more_vert');
+
   clickedItem = output<IDropdownItem>();
   contentID = signal<string>('');
 

--- a/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.stories.ts
@@ -54,7 +54,7 @@ ${getBasicExampleBlock('BmbDropdownMenuComponent', '', '', false, '', 'Activated
     icon: DBmbDropdownMenuParamDesc.icon,
     clickedItem: getOnEventParam(
       {
-        name: 'clickedItem',
+        name: 'clickedItem',   
         handleExample: '(item) => console.log("Clicked item:", item)',
         propertyValue: 'EventEmitter<IDropdownItem>',
         type: 'EventEmitter',

--- a/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown-menu/bmb-dropdown-menu.stories.ts
@@ -51,6 +51,7 @@ ${getBasicExampleBlock('BmbDropdownMenuComponent', '', '', false, '', 'Activated
   },
   argTypes: {
     items: DBmbDropdownMenuParamDesc.items,
+    icon: DBmbDropdownMenuParamDesc.icon,
     clickedItem: getOnEventParam(
       {
         name: 'clickedItem',
@@ -63,6 +64,7 @@ ${getBasicExampleBlock('BmbDropdownMenuComponent', '', '', false, '', 'Activated
     ),
   },
   args: {
+    icon: 'more_vert',
     items: [
       {
         icon: 'link',

--- a/projects/ds-ng/src/lib/utils/doc/parameterDescriptions.ts
+++ b/projects/ds-ng/src/lib/utils/doc/parameterDescriptions.ts
@@ -932,16 +932,15 @@ IBmbTargetLink = '_blank' | '_parent' | '_self' | '_top';
     },
   },
     icon: {
-    control: { type: 'text' },
+    control: { type: 'radio' },
+    options: ['more_vert', 'more_horiz'],
     description: `
-Sets the icon displayed in the dropdown menu trigger button.
-
-This icon is used to open the dropdown menu. Any icon supported by the icon library can be used.
-    `,
+  Sets the icon displayed in the dropdown menu trigger button.
+      `,
     table: {
       category: 'Properties',
       type: {
-        summary: 'string',
+        summary: `'more_vert' | 'more_horiz'`,
       },
       defaultValue: {
         summary: 'more_vert',

--- a/projects/ds-ng/src/lib/utils/doc/parameterDescriptions.ts
+++ b/projects/ds-ng/src/lib/utils/doc/parameterDescriptions.ts
@@ -931,6 +931,23 @@ IBmbTargetLink = '_blank' | '_parent' | '_self' | '_top';
       defaultValue: { summary: '[]' },
     },
   },
+    icon: {
+    control: { type: 'text' },
+    description: `
+Sets the icon displayed in the dropdown menu trigger button.
+
+This icon is used to open the dropdown menu. Any icon supported by the icon library can be used.
+    `,
+    table: {
+      category: 'Properties',
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'more_vert',
+      },
+    },
+  },
 };
 
 export const DBmbTooltipParamDesc = {


### PR DESCRIPTION
[DS01-3394](https://tecdemonterrey.atlassian.net/browse/DS01-3394) - [GH-tec-design-system-ng-1133] Permitir personalizar el ícono del componente bmb-dropdown-menu

## Changes proposed in this PR: 💻

- Icono personalizable en el dropdown menu

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

<img width="590" height="458" alt="image" src="https://github.com/user-attachments/assets/e2e02b20-4c35-461d-a56d-002b35dd19bf" />


## Checklist ✔️

Please check all steps on the checklist

- [✔️ ] My code matches all coding standars.
- [✔️ ] I included the documentation files (.stories.ts).
- [✔️ ] I ran the unit tests before submitting (`npm run test`).
- [✔️ ] I ran the E2E tests before submitting (`npm run e2e`).
- [✔️ ] My code resolved all of the task's acceptance criteria.


[DS01-3394]: https://tecdemonterrey.atlassian.net/browse/DS01-3394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ