### PR TITLE
Add column-builder mixin and replace columns

### DIFF
--- a/projects/ds-ng/src/assets/styles/components/_col-sys.scss
+++ b/projects/ds-ng/src/assets/styles/components/_col-sys.scss
@@ -62,16 +62,28 @@ $alignItemsOptions: (
   ) !important;
 }
 
+@mixin column-builder($index, $columnCount: 12) {
+  flex: 0 0
+    calc(
+      #{math.percentage(math.div($index, $columnCount))} - (var(--bmb-gap) /
+            $columnCount * #{$columnCount - $index})
+    ) !important;
+  max-width: calc(
+    #{math.percentage(math.div($index, $columnCount))} - (var(--bmb-gap) /
+          $columnCount * #{$columnCount - $index})
+  ) !important;
+}
+
 @mixin columns-builder($columnCount, $prefix, $minWidth) {
   @for $i from 1 through $columnCount {
     @if $minWidth == null {
       .bmb_col-#{$prefix}-#{$i} {
-        @include columns($i);
+        @include column-builder($i, $columnCount);
       }
     } @else {
       @include mixins.media-query($minWidth, 'min') {
         .bmb_col-#{$prefix}-#{$i} {
-          @include columns($i);
+          @include column-builder($i, $columnCount);
         }
       }
     }


### PR DESCRIPTION
Introduce a new @mixin column-builder($index, $columnCount: 12) that computes flex and max-width with calc using math.div, math.percentage and var(--bmb-gap). Update @mixin columns-builder to use column-builder($i, $columnCount) instead of the previous columns($i) for both default and media-query branches, ensuring column sizing accounts for gap and configurable column count.

[DS01-XXXX](https://tecdemonterrey.atlassian.net/browse/DS01-XXXX) - ISSUE_TITLE

## Changes proposed in this PR: 💻

-

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit tests before submitting (`npm run test`).
- [ ] I ran the E2E tests before submitting (`npm run e2e`).
- [ ] My code resolved all of the task's acceptance criteria.
