### PR TITLE
feat(component / search card): Se cambió el estado inicial del compon…

### DIFF
--- a/projects/ds-ng/src/assets/styles/base/_color-group-name.scss
+++ b/projects/ds-ng/src/assets/styles/base/_color-group-name.scss
@@ -1,3 +1,4 @@
+
 $font_colors: (
   'creative-use-violet': var(--general-contrasts-5),
   'creative-use-strong': var(--general-contrasts-dark-complementary),

--- a/projects/ds-ng/src/lib/components/bmb-search-card/bmb-search-card-empty-state/bmb-search-card-empty-state.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-search-card/bmb-search-card-empty-state/bmb-search-card-empty-state.component.scss
@@ -3,6 +3,10 @@
 .bmb_search-card-empty-state {
   height: 100%;
 
+  &_icon {
+    opacity: 0.5;
+  }
+
   &_primary {
     @include fonts.font(7, regular);
     font-weight: 400;

--- a/projects/ds-ng/src/lib/components/bmb-search-card/bmb-search-card.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-search-card/bmb-search-card.component.html
@@ -16,86 +16,88 @@
       [control]="inputSearchControl"
       [isLoading]="isLoading()"
     />
-    <bmb-tabs [tabs]="tabsData()" [(selectedTabId)]="selectedTabId">
-      @switch (selectedTabId()) {
-        @case (1) {
-          <div class="bmb_search-card-results">
-            @if (computedResults().services.length) {
-              <section class="bmb_search-card-results-section">
-                <h3>{{ 'search_card.tabs.services' | translate }}</h3>
-                <ul class="bmb_search-card-results-list">
-                  @for (service of computedResults().services; track $index) {
-                    <ng-container
-                      *ngTemplateOutlet="cardItem; context: { item: service }"
-                    ></ng-container>
-                  }
-                </ul>
-              </section>
-            }
-            @if (computedResults().persons.length) {
-              <section class="bmb_search-card-results-section">
-                <h3>{{ 'search_card.tabs.people' | translate }}</h3>
-                <ul class="bmb_search-card-results-list">
-                  @for (person of computedResults().persons; track $index) {
-                    <ng-container
-                      *ngTemplateOutlet="cardItem; context: { item: person }"
-                    ></ng-container>
-                  }
-                </ul>
-              </section>
-            }
-            @if (
-              !computedResults().services.length &&
-              !computedResults().persons.length
-            ) {
-              <bmb-search-card-empty-state
-                [inputHasValue]="!!inputSearchControl.value"
-              ></bmb-search-card-empty-state>
-            }
-          </div>
+    @if (inputSearchControl.value) {
+      <bmb-tabs [tabs]="tabsData()" [(selectedTabId)]="selectedTabId">
+        @switch (selectedTabId()) {
+          @case (1) {
+            <div class="bmb_search-card-results">
+              @if (computedResults().services.length) {
+                <section class="bmb_search-card-results-section">
+                  <h3>{{ 'search_card.tabs.services' | translate }}</h3>
+                  <ul class="bmb_search-card-results-list">
+                    @for (service of computedResults().services; track $index) {
+                      <ng-container
+                        *ngTemplateOutlet="cardItem; context: { item: service }"
+                      ></ng-container>
+                    }
+                  </ul>
+                </section>
+              }
+              @if (computedResults().persons.length) {
+                <section class="bmb_search-card-results-section">
+                  <h3>{{ 'search_card.tabs.people' | translate }}</h3>
+                  <ul class="bmb_search-card-results-list">
+                    @for (person of computedResults().persons; track $index) {
+                      <ng-container
+                        *ngTemplateOutlet="cardItem; context: { item: person }"
+                      ></ng-container>
+                    }
+                  </ul>
+                </section>
+              }
+              @if (
+                !computedResults().services.length &&
+                !computedResults().persons.length
+              ) {
+                <bmb-search-card-empty-state
+                  [inputHasValue]="!!inputSearchControl.value"
+                ></bmb-search-card-empty-state>
+              }
+            </div>
+          }
+          @case (2) {
+            <div class="bmb_search-card-results">
+              @if (computedResults().services.length) {
+                <section class="bmb_search-card-results-section">
+                  <h3>{{ 'search_card.tabs.services' | translate }}</h3>
+                  <ul class="bmb_search-card-results-list">
+                    @for (service of computedResults().services; track $index) {
+                      <ng-container
+                        *ngTemplateOutlet="cardItem; context: { item: service }"
+                      ></ng-container>
+                    }
+                  </ul>
+                </section>
+              } @else {
+                <bmb-search-card-empty-state
+                  [inputHasValue]="!!inputSearchControl.value"
+                ></bmb-search-card-empty-state>
+              }
+            </div>
+          }
+          @case (3) {
+            <div class="bmb_search-card-results">
+              @if (computedResults().persons.length) {
+                <section class="bmb_search-card-results-section">
+                  <h3>{{ 'search_card.tabs.people' | translate }}</h3>
+                  <ul class="bmb_search-card-results-list">
+                    @for (person of computedResults().persons; track $index) {
+                      <ng-container
+                        *ngTemplateOutlet="cardItem; context: { item: person }"
+                      ></ng-container>
+                    }
+                  </ul>
+                </section>
+              } @else {
+                <bmb-search-card-empty-state
+                  [inputHasValue]="!!inputSearchControl.value"
+                ></bmb-search-card-empty-state>
+              }
+            </div>
+          }
         }
-        @case (2) {
-          <div class="bmb_search-card-results">
-            @if (computedResults().services.length) {
-              <section class="bmb_search-card-results-section">
-                <h3>{{ 'search_card.tabs.services' | translate }}</h3>
-                <ul class="bmb_search-card-results-list">
-                  @for (service of computedResults().services; track $index) {
-                    <ng-container
-                      *ngTemplateOutlet="cardItem; context: { item: service }"
-                    ></ng-container>
-                  }
-                </ul>
-              </section>
-            } @else {
-              <bmb-search-card-empty-state
-                [inputHasValue]="!!inputSearchControl.value"
-              ></bmb-search-card-empty-state>
-            }
-          </div>
-        }
-        @case (3) {
-          <div class="bmb_search-card-results">
-            @if (computedResults().persons.length) {
-              <section class="bmb_search-card-results-section">
-                <h3>{{ 'search_card.tabs.people' | translate }}</h3>
-                <ul class="bmb_search-card-results-list">
-                  @for (person of computedResults().persons; track $index) {
-                    <ng-container
-                      *ngTemplateOutlet="cardItem; context: { item: person }"
-                    ></ng-container>
-                  }
-                </ul>
-              </section>
-            } @else {
-              <bmb-search-card-empty-state
-                [inputHasValue]="!!inputSearchControl.value"
-              ></bmb-search-card-empty-state>
-            }
-          </div>
-        }
-      }
-    </bmb-tabs>
+      </bmb-tabs>
+    }
     {{ isLoading() ? 'Loading...' : '' }}
   </bmb-home-card>
 </section>


### PR DESCRIPTION
[DS01-3217](https://tecdemonterrey.atlassian.net/browse/DS01-3217) - Search card: Agregar configuración donde el 1er clic hablita las tabs y enfoque inicial.

## Changes proposed in this PR: 💻

Mejoras en el componente `bmb-search-card`, centrándose en la representación condicional de las pestañas, mejoras de estilo para el estado vacío y actualizaciones de las variables de color. Los cambios buscan mejorar la experiencia del usuario mostrando solo los elementos de la interfaz relevantes cuando sea apropiado y mejorando la claridad visual.

**Lógica y representación del componente:**

* Se actualizó `bmb-search-card.component.html` para que el elemento `bmb-tabs` se muestre condicionalmente solo cuando el campo de búsqueda tenga un valor, asegurando que las pestañas se muestren únicamente cuando sean relevantes. [[1]](diffhunk://#diff-c9b6a662f9540c26b46fab15800b8998875a6ccd29310ce5a2e147f15553e751R19) [[2]](diffhunk://#diff-c9b6a662f9540c26b46fab15800b8998875a6ccd29310ce5a2e147f15553e751R100)

**Mejoras de estilo:**

* Se agregó un nuevo estilo para el ícono de estado vacío en `bmb-search-card-empty-state.component.scss`, estableciendo su opacidad en 0.5 para una mejor distinción visual.

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

<img width="517" height="219" alt="image" src="https://github.com/user-attachments/assets/35949210-0413-4b39-a5df-b6d3c6f80d11" />


## Checklist ✔️

Please check all steps on the checklist

- [x] My code matches all coding standars.
- [x] I included the documentation files (.stories.ts).
- [x] I ran the unit tests before submitting (`npm run test`).
- [x] I ran the E2E tests before submitting (`npm run e2e`).
- [x] My code resolved all of the task's acceptance criteria.


[DS01-3217]: https://tecdemonterrey.atlassian.net/browse/DS01-3217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ