### PR TITLE
fix(componente): evitar evento doble en arrow-down de dropdown

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-dropdown/bmb-dropdown.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-dropdown/bmb-dropdown.component.html
@@ -52,7 +52,7 @@
             <bmb-action-icon
               [icon]="isOpenList ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
               [iconSize]="24"
-              (buttonClick)="openList()"
+              (buttonClick)="$event.preventDefault(); openList()"
               bmbLayoutItem
               [alt]="
                 (isOpenList


### PR DESCRIPTION
[DS01-XXXX](https://tecdemonterrey.atlassian.net/browse/DS01-XXXX) - ISSUE_TITLE

## Changes proposed in this PR: 💻

- Ajuste en componente dropdown para evitar el doble evento al dar clic en en arrow-down de componente dropdwon

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

Primer imagen evento doble que muestra lista de varios dropdown (no toma en cuenta si el id se duplica ente componentes)

<img width="1224" height="668" alt="image" src="https://github.com/user-attachments/assets/b40cb6ad-f754-4ac9-b405-38e9c159422f" />

Segunda imagen: Evita la ejecución de eventos en cadena dentro del componente del dropdwon
<img width="1244" height="614" alt="image" src="https://github.com/user-attachments/assets/ffab97af-be66-4f0e-b5fb-128052acc5d2" />

Evento que por alguna razón se ejecuta en el navogador de firefox, versión (152.0.4)

## Checklist ✔️

Please check all steps on the checklist

- [X] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [X] I ran the unit tests before submitting (`npm run test`).
- [X] I ran the E2E tests before submitting (`npm run e2e`).
