### PR TITLE
fix(componente) bmb-dropzone agregar validacione en archivos duplicad…

### DIFF
--- a/projects/ds-ng/src/assets/i18n/en.json
+++ b/projects/ds-ng/src/assets/i18n/en.json
@@ -90,7 +90,6 @@
     "error_message_format": "Unsupported format",
     "error_message_size": "File size exceeds the allowed limit",
     "error_message_invalid_name": "Invalid file name",
-    "error_message_duplicate": "Invalid duplicate file",
     "format_files_label": "Specification of formats and weight",
     "link_label": "View more information about accepted file formats."
   },

--- a/projects/ds-ng/src/assets/i18n/en.json
+++ b/projects/ds-ng/src/assets/i18n/en.json
@@ -89,6 +89,8 @@
     "error_message": "Unsupported file",
     "error_message_format": "Unsupported format",
     "error_message_size": "File size exceeds the allowed limit",
+    "error_message_invalid_name": "Invalid file name",
+    "error_message_duplicate": "Invalid duplicate file",
     "format_files_label": "Specification of formats and weight",
     "link_label": "View more information about accepted file formats."
   },

--- a/projects/ds-ng/src/assets/i18n/es.json
+++ b/projects/ds-ng/src/assets/i18n/es.json
@@ -90,7 +90,6 @@
     "error_message_format": "Formato no soportado",
     "error_message_size": "El archivo supera el tamaño permitido",
     "error_message_invalid_name": "Nombre de archivo no valido",
-    "error_message_duplicate": "Archivo duplicado no valido",
     "format_files_label": "Especificación de formatos y peso",
     "link_label": "Ver más información de formatos de archivo aceptados."
   },

--- a/projects/ds-ng/src/assets/i18n/es.json
+++ b/projects/ds-ng/src/assets/i18n/es.json
@@ -89,6 +89,8 @@
     "error_message": "Archivo no compatible",
     "error_message_format": "Formato no soportado",
     "error_message_size": "El archivo supera el tamaño permitido",
+    "error_message_invalid_name": "Nombre de archivo no valido",
+    "error_message_duplicate": "Archivo duplicado no valido",
     "format_files_label": "Especificación de formatos y peso",
     "link_label": "Ver más información de formatos de archivo aceptados."
   },

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.html
@@ -63,14 +63,16 @@
           />
         </label>
       </p>
-      @if (isErrorFiles()) {
-        <p
-          class="bmb_drop-zone-label-error"
-          bmbVerticalLayoutItem
-          [isFullWidth]="false"
-        >
-          {{ errorMessageLabel }}
-        </p>
+      @if (visibleErrorMessages.length) {
+        @for (message of visibleErrorMessages; track $index) {
+          <p
+            class="bmb_drop-zone-label-error"
+            bmbVerticalLayoutItem
+            [isFullWidth]="false"
+          >
+            {{ message }}
+          </p>
+        }
         @if (!!linkFilesSupported() && !!linkLabel()) {
           <bmb-text-link
             textLinkStyle="underlined"
@@ -83,7 +85,7 @@
       }
     </section>
     @if (!!fileDataList.length) {
-      @for (file of organizedFiles; track $index) {
+      @for (file of organizedFiles; track file.id) {
         <bmb-progress-bar
           class="bmb-drop-zone-file"
           [ngClass]="{
@@ -112,7 +114,7 @@
           [avatarIcon]="getAvatarIcon(file)"
           [actionIcon]="file.error ? 'close' : 'delete'"
           [showStatusIcon]="isUploadCompleted(file)"
-          (actionClick)="handleRemoveFile(file.name)"
+          (actionClick)="handleRemoveFile(file)"
           bmbVerticalLayoutItem
         />
       }

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.html
@@ -83,7 +83,7 @@
       }
     </section>
     @if (!!fileDataList.length) {
-      @for (file of organizedFiles; track file.name) {
+      @for (file of organizedFiles; track $index) {
         <bmb-progress-bar
           class="bmb-drop-zone-file"
           [ngClass]="{

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.spec.ts
@@ -17,10 +17,46 @@ describe('DropzoneComponent', () => {
     component = fixture.componentInstance;
     componentRef = fixture.componentRef;
     componentRef.setInput('acceptedExtensions', ['pdf']);
+    componentRef.setInput('multiple', true);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should reject a file with invalid characters and show its error message', () => {
+    const newFileSpy = spyOn(component.newFile, 'emit');
+    const invalidFile = new File(['content'], 'reporte#final.pdf', {
+      type: 'application/pdf',
+    });
+
+    (component as any).handleFileSelected({
+      target: { files: [invalidFile], value: 'selected-file' },
+    } as unknown as Event);
+    fixture.detectChanges();
+
+    expect(newFileSpy).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain(
+      'Nombre de archivo no valido',
+    );
+  });
+
+  it('should reject the repeated file and show its duplicate error message', () => {
+    const newFileSpy = spyOn(component.newFile, 'emit');
+    const file = new File(['content'], 'archivo-valido.pdf', {
+      type: 'application/pdf',
+    });
+
+    (component as any).handleFileSelected({
+      target: { files: [file, file], value: 'selected-files' },
+    } as unknown as Event);
+    fixture.detectChanges();
+
+    expect(newFileSpy).toHaveBeenCalledTimes(1);
+    expect(newFileSpy).toHaveBeenCalledWith([file]);
+    expect(fixture.nativeElement.textContent).toContain(
+      'Archivo duplicado no valido',
+    );
   });
 });

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BmbDropzoneComponent } from './bmb-dropzone.component';
 import { ComponentRef } from '@angular/core';
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 describe('DropzoneComponent', () => {
   let component: BmbDropzoneComponent;
@@ -18,14 +19,15 @@ describe('DropzoneComponent', () => {
     componentRef = fixture.componentRef;
     componentRef.setInput('acceptedExtensions', ['pdf']);
     componentRef.setInput('multiple', true);
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should reject a file with invalid characters and show its error message', () => {
+    fixture.detectChanges();
     const newFileSpy = spyOn(component.newFile, 'emit');
     const invalidFile = new File(['content'], 'reporte#final.pdf', {
       type: 'application/pdf',
@@ -42,21 +44,77 @@ describe('DropzoneComponent', () => {
     );
   });
 
-  it('should reject the repeated file and show its duplicate error message', () => {
+  it('should preserve the default behavior and ignore duplicate files', () => {
+    fixture.detectChanges();
     const newFileSpy = spyOn(component.newFile, 'emit');
-    const file = new File(['content'], 'archivo-valido.pdf', {
-      type: 'application/pdf',
+    const file = createPdfFile('archivo-valido.pdf');
+
+    selectFiles([file, file]);
+
+    expect(newFileSpy).toHaveBeenCalledOnceWith([file]);
+  });
+
+  it('should allow duplicate files when allowDuplicateFiles is true', () => {
+    componentRef.setInput('allowDuplicateFiles', true);
+    fixture.detectChanges();
+    const newFileSpy = spyOn(component.newFile, 'emit');
+    const file = createPdfFile('archivo-valido.pdf');
+
+    selectFiles([file, file]);
+
+    expect(newFileSpy).toHaveBeenCalledOnceWith([file, file]);
+    expect(component.control().value).toEqual([
+      'archivo-valido.pdf',
+      'archivo-valido.pdf',
+    ]);
+  });
+
+  it('should display multiple custom validation messages on separate lines', () => {
+    const duplicateValidator: ValidatorFn = (
+      control: AbstractControl,
+    ): ValidationErrors | null => {
+      const names = control.value as string[];
+      return new Set(names).size !== names.length
+        ? { duplicateFileName: true }
+        : null;
+    };
+    const reviewValidator: ValidatorFn = (): ValidationErrors => ({
+      reviewRequired: true,
     });
 
-    (component as any).handleFileSelected({
-      target: { files: [file, file], value: 'selected-files' },
-    } as unknown as Event);
+    componentRef.setInput('allowDuplicateFiles', true);
+    componentRef.setInput('customValidation', [
+      duplicateValidator,
+      reviewValidator,
+    ]);
+    componentRef.setInput('customErrorMessages', {
+      duplicateFileName: 'Archivo duplicado no válido',
+      reviewRequired: 'Los archivos requieren revisión manual',
+    });
     fixture.detectChanges();
 
-    expect(newFileSpy).toHaveBeenCalledTimes(1);
-    expect(newFileSpy).toHaveBeenCalledWith([file]);
-    expect(fixture.nativeElement.textContent).toContain(
-      'Archivo duplicado no valido',
-    );
+    const file = createPdfFile('archivo-valido.pdf');
+    selectFiles([file, file]);
+    fixture.detectChanges();
+
+    const errorMessages = Array.from(
+      fixture.nativeElement.querySelectorAll('.bmb_drop-zone-label-error'),
+    ).map((element: unknown) => (element as HTMLElement).textContent?.trim());
+
+    expect(errorMessages).toEqual([
+      'Archivo duplicado no válido',
+      'Los archivos requieren revisión manual',
+    ]);
   });
+
+  function createPdfFile(name: string): File {
+    return new File(['content'], name, { type: 'application/pdf' });
+  }
+
+  function selectFiles(files: File[]): void {
+    (component as any).handleFileSelected({
+      target: { files, value: 'selected-files' },
+    } as unknown as Event);
+    fixture.detectChanges();
+  }
 });

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
@@ -34,11 +34,12 @@ import {
 import { BmbInputValidatorComponent } from '../bmb-input/bmb-input-validator/bmb-input-validator.component';
 
 interface FileData {
+  id: string;
   name: string;
   size: number;
   base64?: string;
   error?: boolean;
-  errorType?: 'format' | 'size' | 'name' | 'duplicate' | null;
+  errorType?: 'format' | 'size' | 'name' | null;
 }
 
 interface IBmbFileValidation {
@@ -76,17 +77,18 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   errorMessageFormat = input<string>();
   errorMessageSize = input<string>();
   errorMessageInvalidName = input<string>();
-  errorMessageDuplicate = input<string>();
   fileSize = input<number>(2);
   formatFilesLabel = input<string>();
   linkFilesSupported = input<string>('');
   linkLabel = input<string>();
   mainIcon = input<string>('image');
   multiple = input<boolean>(false);
+  allowDuplicateFiles = input<boolean>(false);
   name = input<string>(getUUID());
   progress = input<Record<string, number> | number>({});
   inputId = input<string>(this.name());
-  customValidation = input<ValidatorFn>();
+  customValidation = input<ValidatorFn | ValidatorFn[]>();
+  customErrorMessages = input<Record<string, string>>({});
 
   control = model<FormControl>(newFormControlByType('file', this.multiple()));
 
@@ -152,7 +154,7 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
     return classList;
   }
 
-  protected get errorMessageLabel(): string {
+  protected get errorMessageLabels(): string[] {
     const messages: string[] = [];
 
     if (this.isFormatErrorFiles()) {
@@ -177,14 +179,22 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
           ),
       );
     }
-    if (this.isDuplicateErrorFiles()) {
-      messages.push(
-        this.errorMessageDuplicate() ||
-          this.translationService.translate('dropzone.error_message_duplicate'),
-      );
-    }
+    return messages.map((message) => `${message}*`);
+  }
 
-    return messages.map((message) => `${message}*`).join(' ');
+  protected get customErrorMessageLabels(): string[] {
+    const errors = this.control()?.errors;
+    const messages = this.customErrorMessages();
+
+    if (!errors) return [];
+
+    return Object.keys(errors)
+      .filter((errorKey) => !!messages[errorKey])
+      .map((errorKey) => messages[errorKey]);
+  }
+
+  protected get visibleErrorMessages(): string[] {
+    return [...this.errorMessageLabels, ...this.customErrorMessageLabels];
   }
 
   protected getAvatarIcon(file: FileData): string {
@@ -246,13 +256,10 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
     }
 
     for (const singleFile of fileList) {
-      if (this.isFileDuplicate(singleFile.name)) {
-        this.fileDataList.push({
-          name: singleFile.name,
-          size: this.getFileSizeInMB(singleFile.size),
-          error: true,
-          errorType: 'duplicate',
-        });
+      if (
+        !this.allowDuplicateFiles() &&
+        this.isFileDuplicate(singleFile.name)
+      ) {
         continue;
       }
 
@@ -262,6 +269,7 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
         isValidName: this.isValidFileName(singleFile.name),
       };
       const fileData: FileData = {
+        id: getUUID(),
         name: singleFile.name,
         size: this.getFileSizeInMB(singleFile.size),
         error:
@@ -286,7 +294,16 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
 
     if (!!validFiles.length) {
       if (this.multiple()) {
-        this.control().patchValue(validFiles.map((_file: any) => _file.name));
+        const newFileNames = validFiles.map((_file: File) => _file.name);
+        const currentFileNames = Array.isArray(this.control().value)
+          ? this.control().value.filter(Boolean)
+          : [];
+
+        this.control().patchValue(
+          this.allowDuplicateFiles()
+            ? [...currentFileNames, ...newFileNames]
+            : newFileNames,
+        );
         this.control().updateValueAndValidity();
 
         this.newFile.emit(validFiles);
@@ -352,7 +369,10 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   }
 
   protected isErrorFiles(): boolean {
-    return this.fileDataList.some((file) => file.error);
+    return (
+      this.fileDataList.some((file) => file.error) ||
+      !!this.customErrorMessageLabels.length
+    );
   }
 
   private isFormatError(file: FileData): boolean {
@@ -374,12 +394,6 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   protected isNameErrorFiles(): boolean {
     return this.fileDataList.some(
       (file) => file.error && file.errorType === 'name',
-    );
-  }
-
-  protected isDuplicateErrorFiles(): boolean {
-    return this.fileDataList.some(
-      (file) => file.error && file.errorType === 'duplicate',
     );
   }
 
@@ -422,24 +436,24 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
     _input.value = '';
   }
 
-  protected handleRemoveFile(fileName: string): void {
+  protected handleRemoveFile(file: FileData): void {
     this.fileDataList = this.fileDataList.filter(
-      (file) => file.name !== fileName,
+      (existingFile) => existingFile.id !== file.id,
     );
 
     if (this.multiple()) {
-      const _fileNames = this.control().value;
-      this.control().patchValue(
-        Array.from(_fileNames).filter((_fileName) => _fileName !== fileName),
-      );
+      const fileNames = Array.from(this.control().value ?? []);
+      const fileIndex = fileNames.indexOf(file.name);
+      if (fileIndex >= 0) fileNames.splice(fileIndex, 1);
+      this.control().patchValue(fileNames);
       this.control().updateValueAndValidity();
     } else {
       const _fileName = this.control().value;
-      this.control().patchValue(_fileName === fileName ? null : _fileName);
+      this.control().patchValue(_fileName === file.name ? null : _fileName);
       this.control().updateValueAndValidity();
     }
 
-    this.fileRemoved.emit(fileName);
+    this.fileRemoved.emit(file.name);
   }
 
   handleValidity(): void {

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.component.ts
@@ -38,12 +38,13 @@ interface FileData {
   size: number;
   base64?: string;
   error?: boolean;
-  errorType?: 'format' | 'size' | null;
+  errorType?: 'format' | 'size' | 'name' | 'duplicate' | null;
 }
 
 interface IBmbFileValidation {
   isValidFormat: boolean;
   isValidSize: boolean;
+  isValidName: boolean;
 }
 
 @Component({
@@ -74,6 +75,8 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   errorMessage = input<string>(); //Deprecated
   errorMessageFormat = input<string>();
   errorMessageSize = input<string>();
+  errorMessageInvalidName = input<string>();
+  errorMessageDuplicate = input<string>();
   fileSize = input<number>(2);
   formatFilesLabel = input<string>();
   linkFilesSupported = input<string>('');
@@ -150,21 +153,38 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   }
 
   protected get errorMessageLabel(): string {
-    return `${
-      this.isFormatErrorFiles()
-        ? (
-            this.errorMessageFormat()! ||
-            this.translationService.translate('dropzone.error_message_format')
-          ).concat('* ')
-        : ''
-    }${
-      this.isSizeErrorFiles()
-        ? (
-            this.errorMessageSize() ||
-            this.translationService.translate('dropzone.error_message_size')
-          ).concat(' MB*')
-        : ''
-    }`;
+    const messages: string[] = [];
+
+    if (this.isFormatErrorFiles()) {
+      messages.push(
+        this.errorMessageFormat() ||
+          this.translationService.translate('dropzone.error_message_format'),
+      );
+    }
+    if (this.isSizeErrorFiles()) {
+      messages.push(
+        `${
+          this.errorMessageSize() ||
+          this.translationService.translate('dropzone.error_message_size')
+        } ${this.fileSize()} MB`,
+      );
+    }
+    if (this.isNameErrorFiles()) {
+      messages.push(
+        this.errorMessageInvalidName() ||
+          this.translationService.translate(
+            'dropzone.error_message_invalid_name',
+          ),
+      );
+    }
+    if (this.isDuplicateErrorFiles()) {
+      messages.push(
+        this.errorMessageDuplicate() ||
+          this.translationService.translate('dropzone.error_message_duplicate'),
+      );
+    }
+
+    return messages.map((message) => `${message}*`).join(' ');
   }
 
   protected getAvatarIcon(file: FileData): string {
@@ -175,7 +195,7 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
   }
 
   protected getFileName(file: FileData): string {
-    return this.isFormatError(file) ? file.name.concat('*') : file.name;
+    return file.error ? file.name.concat('*') : file.name;
   }
 
   protected getFormatProgress(value: string, total: string): string {
@@ -227,22 +247,40 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
 
     for (const singleFile of fileList) {
       if (this.isFileDuplicate(singleFile.name)) {
+        this.fileDataList.push({
+          name: singleFile.name,
+          size: this.getFileSizeInMB(singleFile.size),
+          error: true,
+          errorType: 'duplicate',
+        });
         continue;
       }
 
       const fileValidation: IBmbFileValidation = {
         isValidFormat: this.isValidFileFormat(singleFile.type, singleFile.name),
         isValidSize: this.isValidFileSize(singleFile.size),
+        isValidName: this.isValidFileName(singleFile.name),
       };
       const fileData: FileData = {
         name: singleFile.name,
         size: this.getFileSizeInMB(singleFile.size),
-        error: !fileValidation.isValidFormat || !fileValidation.isValidSize,
-        errorType: !fileValidation.isValidFormat ? 'format' : 'size',
+        error:
+          !fileValidation.isValidFormat ||
+          !fileValidation.isValidSize ||
+          !fileValidation.isValidName,
+        errorType: !fileValidation.isValidName
+          ? 'name'
+          : !fileValidation.isValidFormat
+            ? 'format'
+            : 'size',
       };
 
       this.fileDataList.push(fileData);
-      if (fileValidation.isValidFormat && fileValidation.isValidSize)
+      if (
+        fileValidation.isValidFormat &&
+        fileValidation.isValidSize &&
+        fileValidation.isValidName
+      )
         validFiles.push(singleFile);
     }
 
@@ -297,6 +335,10 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
     return this.getFileSizeInMB(fileSize) <= this.fileSize();
   }
 
+  private isValidFileName(fileName: string): boolean {
+    return /^[a-zA-Z0-9._-]+$/.test(fileName);
+  }
+
   private isFileDuplicate(fileName: string): boolean {
     return this.fileDataList.some((existing) => existing.name === fileName);
   }
@@ -327,6 +369,18 @@ export class BmbDropzoneComponent implements OnInit, OnChanges {
 
   protected isSizeErrorFiles(): boolean {
     return this.fileDataList.some((file) => this.isSizeError(file));
+  }
+
+  protected isNameErrorFiles(): boolean {
+    return this.fileDataList.some(
+      (file) => file.error && file.errorType === 'name',
+    );
+  }
+
+  protected isDuplicateErrorFiles(): boolean {
+    return this.fileDataList.some(
+      (file) => file.error && file.errorType === 'duplicate',
+    );
   }
 
   protected handleDragOver(event: DragEvent) {

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.stories.ts
@@ -1,6 +1,12 @@
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import {
+  AbstractControl,
+  FormsModule,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BmbDropzoneComponent } from './bmb-dropzone.component';
 import {
@@ -17,6 +23,22 @@ import {
   getDefaultValueControl,
   getOnEventParam,
 } from '../../utils/doc/parameterDescriptions';
+
+const duplicateFileNameValidator: ValidatorFn = (
+  control: AbstractControl,
+): ValidationErrors | null => {
+  const fileNames = (
+    Array.isArray(control.value) ? control.value : [control.value]
+  ).filter(Boolean);
+
+  return new Set(fileNames).size !== fileNames.length
+    ? { duplicateFileName: true }
+    : null;
+};
+
+const reviewRequiredValidator: ValidatorFn = (): ValidationErrors => ({
+  reviewRequired: true,
+});
 
 export default {
   title: 'Components/Inputs/Dropzone',
@@ -354,15 +376,6 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
         type: { summary: 'string' },
       },
     },
-    errorMessageDuplicate: {
-      control: { type: 'text' },
-      description: 'Sets the message shown when a duplicate file is selected.',
-      table: {
-        category: 'Properties',
-        defaultValue: getDefaultValueControl('Archivo duplicado no valido'),
-        type: { summary: 'string' },
-      },
-    },
     name: DBmbInputParamDesc.name,
     fileSize: {
       control: { type: 'number' },
@@ -380,6 +393,26 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
         category: 'Properties',
         type: { summary: 'boolean' },
         defaultValue: getDefaultValueControl(false),
+      },
+    },
+    allowDuplicateFiles: {
+      control: { type: 'boolean' },
+      description:
+        'Allows files with the same name. It is disabled by default to preserve the existing behavior.',
+      table: {
+        category: 'Properties',
+        type: { summary: 'boolean' },
+        defaultValue: getDefaultValueControl(false),
+      },
+    },
+    customErrorMessages: {
+      control: { type: 'object' },
+      description:
+        'Maps custom validation error keys to the messages displayed by the dropzone.',
+      table: {
+        category: 'Properties',
+        type: { summary: 'Record<string, string>' },
+        defaultValue: { summary: '{}' },
       },
     },
     newFile: getOnEventParam(
@@ -407,9 +440,10 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
     errorMessageFormat: 'Format not compatible',
     errorMessageSize: 'File exceeds the maximum allowed size.',
     errorMessageInvalidName: 'Invalid file name',
-    errorMessageDuplicate: 'Invalid duplicate file',
     fileSize: 2,
     multiple: false,
+    allowDuplicateFiles: false,
+    customErrorMessages: {},
   },
 } as Meta<typeof BmbDropzoneComponent>;
 
@@ -423,8 +457,49 @@ export const FileNameValidation: Story = {
     formatFilesLabel:
       'Prueba nombres con #, @, %, acentos, espacios o paréntesis.',
     errorMessageInvalidName: 'Nombre de archivo no valido',
-    errorMessageDuplicate: 'Archivo duplicado no valido',
     multiple: true,
+    progress: {},
+  },
+};
+
+export const DuplicateFilesAllowed: Story = {
+  args: {
+    acceptedExtensions: ['pdf', 'application/pdf'],
+    formatFilesLabel:
+      'Los archivos con el mismo nombre están permitidos en este escenario.',
+    multiple: true,
+    allowDuplicateFiles: true,
+    progress: {},
+  },
+};
+
+export const DuplicateFilesRejectedByCustomValidation: Story = {
+  args: {
+    acceptedExtensions: ['pdf', 'application/pdf'],
+    formatFilesLabel:
+      'Selecciona dos veces un PDF con el mismo nombre para activar el error.',
+    multiple: true,
+    allowDuplicateFiles: true,
+    customValidation: duplicateFileNameValidator,
+    customErrorMessages: {
+      duplicateFileName: 'Archivo duplicado no válido',
+    },
+    progress: {},
+  },
+};
+
+export const MultipleCustomErrors: Story = {
+  args: {
+    acceptedExtensions: ['pdf', 'application/pdf'],
+    formatFilesLabel:
+      'Los errores personalizados se muestran en líneas independientes.',
+    multiple: true,
+    allowDuplicateFiles: true,
+    customValidation: [duplicateFileNameValidator, reviewRequiredValidator],
+    customErrorMessages: {
+      duplicateFileName: 'Archivo duplicado no válido',
+      reviewRequired: 'Los archivos requieren revisión manual',
+    },
     progress: {},
   },
 };

--- a/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-dropzone/bmb-dropzone.stories.ts
@@ -344,6 +344,25 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
         type: { summary: 'string' },
       },
     },
+    errorMessageInvalidName: {
+      control: { type: 'text' },
+      description:
+        'Sets the message shown when a file name contains unsupported characters.',
+      table: {
+        category: 'Properties',
+        defaultValue: getDefaultValueControl('Nombre de archivo no valido'),
+        type: { summary: 'string' },
+      },
+    },
+    errorMessageDuplicate: {
+      control: { type: 'text' },
+      description: 'Sets the message shown when a duplicate file is selected.',
+      table: {
+        category: 'Properties',
+        defaultValue: getDefaultValueControl('Archivo duplicado no valido'),
+        type: { summary: 'string' },
+      },
+    },
     name: DBmbInputParamDesc.name,
     fileSize: {
       control: { type: 'number' },
@@ -387,6 +406,8 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
     mainIcon: 'image',
     errorMessageFormat: 'Format not compatible',
     errorMessageSize: 'File exceeds the maximum allowed size.',
+    errorMessageInvalidName: 'Invalid file name',
+    errorMessageDuplicate: 'Invalid duplicate file',
     fileSize: 2,
     multiple: false,
   },
@@ -395,3 +416,15 @@ ${RELEVANT_TITLE.example} ***image/**** is for all image types:
 type Story = StoryObj<BmbDropzoneComponent>;
 
 export const Default: Story = {};
+
+export const FileNameValidation: Story = {
+  args: {
+    acceptedExtensions: ['pdf', 'application/pdf', 'csv', 'text/csv'],
+    formatFilesLabel:
+      'Prueba nombres con #, @, %, acentos, espacios o paréntesis.',
+    errorMessageInvalidName: 'Nombre de archivo no valido',
+    errorMessageDuplicate: 'Archivo duplicado no valido',
+    multiple: true,
+    progress: {},
+  },
+};

--- a/src/app/pages/dropzone/dropzone.component.html
+++ b/src/app/pages/dropzone/dropzone.component.html
@@ -3,12 +3,73 @@
   (formGroupState)="handleFormGroupState($event)"
 >
   <section bmbVerticalLayout justify="center" alignItems="center" gapSize="xl">
+    <section
+      bmbVerticalLayout
+      gapSize="m"
+      bmbVerticalLayoutItem
+      style="max-width: 640px"
+    >
+      <section bmbVerticalLayoutItem>
+        <label for="multiple-files-switch">
+          <strong>Selección múltiple</strong>
+          — multiple: {{ multipleFiles() }}
+        </label>
+        <bmb-switch
+          inputId="multiple-files-switch"
+          ariaLabel="Activar o desactivar la selección múltiple"
+          [isChecked]="multipleFiles()"
+          (change)="handleMultipleFilesChange($event)"
+        />
+      </section>
+      <section bmbVerticalLayoutItem>
+        <label for="duplicate-files-switch">
+          <strong>Permitir archivos duplicados</strong>
+          — allowDuplicateFiles: {{ allowDuplicateFiles() }}
+        </label>
+        <bmb-switch
+          inputId="duplicate-files-switch"
+          ariaLabel="Permitir o rechazar archivos con el mismo nombre"
+          [isChecked]="allowDuplicateFiles()"
+          [disabled]="!multipleFiles()"
+          (change)="handleAllowDuplicateFilesChange($event)"
+        />
+      </section>
+      <section bmbVerticalLayoutItem>
+        <label for="duplicate-validation-switch">
+          <strong>Validar nombres duplicados</strong>
+          — customValidation: {{ validateDuplicateFiles() }}
+        </label>
+        <bmb-switch
+          inputId="duplicate-validation-switch"
+          ariaLabel="Activar o desactivar la validación personalizada de archivos duplicados"
+          [isChecked]="validateDuplicateFiles()"
+          [disabled]="!multipleFiles()"
+          (change)="handleDuplicateValidationChange($event)"
+        />
+      </section>
+      <p bmbVerticalLayoutItem>
+        Estado actual: multiple = <strong>{{ multipleFiles() }}</strong
+        >, allowDuplicateFiles = <strong>{{ allowDuplicateFiles() }}</strong
+        >, customValidation =
+        <strong>{{ validateDuplicateFiles() }}</strong>
+      </p>
+      <small bmbVerticalLayoutItem>
+        Para probar el mensaje de duplicado activa los tres switches y
+        selecciona dos veces un archivo con el mismo nombre.
+      </small>
+    </section>
+
     <bmb-dropzone
       inputId="dropzone_id"
       name="dropzone"
-      [acceptedExtensions]="['csv']"
+      [acceptedExtensions]="['csv', 'png']"
       [fileSize]="1"
-      [multiple]="true"
+      [multiple]="multipleFiles()"
+      [allowDuplicateFiles]="allowDuplicateFiles()"
+      [customValidation]="duplicateFileValidation"
+      [customErrorMessages]="
+        validateDuplicateFiles() ? customErrorMessages : noCustomErrorMessages
+      "
       [progress]="progressFiles()"
       linkLabel="Ver más información de formatos de archivo aceptados."
       linkFilesSupported="https://www.youtube.com/"

--- a/src/app/pages/dropzone/dropzone.component.ts
+++ b/src/app/pages/dropzone/dropzone.component.ts
@@ -1,12 +1,19 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import {
   BmbDropzoneComponent,
   BmbButtonDirective,
   BmbFilterCardComponent,
   IBmbControlType,
   BmbFormValidatorComponent,
+  BmbSwitchComponent,
 } from '../../../../projects/ds-ng/src/public-api';
-import { FormControl, FormGroup } from '@angular/forms';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  ValidatorFn,
+} from '@angular/forms';
 
 @Component({
   selector: 'bmb-dropzone-page',
@@ -17,18 +24,67 @@ import { FormControl, FormGroup } from '@angular/forms';
     BmbDropzoneComponent,
     BmbButtonDirective,
     BmbFilterCardComponent,
+    BmbSwitchComponent,
   ],
 })
 export class DropzonePageComponent {
+  @ViewChild(BmbDropzoneComponent) dropzone?: BmbDropzoneComponent;
+
   userForm: FormGroup = new FormGroup({
     dropzone: new FormControl(),
   });
   progressFiles = signal<Record<string, number>>({});
+  multipleFiles = signal<boolean>(true);
+  allowDuplicateFiles = signal<boolean>(false);
+  validateDuplicateFiles = signal<boolean>(false);
+
+  readonly duplicateFileValidation: ValidatorFn = (
+    control: AbstractControl,
+  ): ValidationErrors | null => {
+    if (!this.validateDuplicateFiles()) return null;
+
+    const fileNames = (
+      Array.isArray(control.value) ? control.value : [control.value]
+    ).filter(Boolean);
+
+    return new Set(fileNames).size !== fileNames.length
+      ? { duplicateFileName: true }
+      : null;
+  };
+
+  readonly customErrorMessages: Record<string, string> = {
+    duplicateFileName: 'Archivo duplicado no válido',
+  };
+  readonly noCustomErrorMessages: Record<string, string> = {};
 
   _isLoading = signal<boolean>(false);
 
   getFormControl(name: string): FormControl {
     return this.userForm.get(name) as FormControl;
+  }
+
+  handleMultipleFilesChange(enabled: boolean): void {
+    this.multipleFiles.set(enabled);
+    if (!enabled) {
+      this.allowDuplicateFiles.set(false);
+      this.validateDuplicateFiles.set(false);
+    }
+    this.updateDropzoneValidity();
+  }
+
+  handleAllowDuplicateFilesChange(enabled: boolean): void {
+    this.allowDuplicateFiles.set(enabled);
+    if (!enabled) this.validateDuplicateFiles.set(false);
+    this.updateDropzoneValidity();
+  }
+
+  handleDuplicateValidationChange(enabled: boolean): void {
+    this.validateDuplicateFiles.set(enabled);
+    this.updateDropzoneValidity();
+  }
+
+  private updateDropzoneValidity(): void {
+    this.dropzone?.control().updateValueAndValidity();
   }
 
   onSubmit() {


### PR DESCRIPTION
…os y caracteres no validos en nombre

[DS01-3643](https://tecdemonterrey.atlassian.net/browse/DS01-3643) - [GH-tec-design-system-ng-1205] bmb-dropzone no se muestran errores del control

## Changes proposed in this PR: 💻

- Validación a caracteres no válidos y mostrar mensaje de error
- Validación a archivos duplicados en base al nobre y mostrar error

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴



Add screenshots of the result of your changes proposed.

<img width="1021" height="575" alt="image" src="https://github.com/user-attachments/assets/32290c6a-985a-4940-ae18-d0bb256ec2ea" />
<img width="1002" height="602" alt="image" src="https://github.com/user-attachments/assets/efb92aef-bb32-473d-b4a6-6cb6e5ab3c61" />
<img width="1018" height="744" alt="image" src="https://github.com/user-attachments/assets/98186ef5-acd7-486a-8836-dc744e4f2757" />


## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit tests before submitting (`npm run test`).
- [ ] I ran the E2E tests before submitting (`npm run e2e`).
- [ ] My code resolved all of the task's acceptance criteria.


[DS01-3643]: https://tecdemonterrey.atlassian.net/browse/DS01-3643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ