### PR TITLE
feat(componente) se agrego input boxShape para manipular el border-ra…

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.html
@@ -1,4 +1,4 @@
-<span class="bmb_box-icon" [ngClass]="[boxSize(), colorName]">
+<span class="bmb_box-icon" [ngClass]="[boxSize(), boxShape(), colorName]">
   <bmb-icon
     [icon]="iconName()"
     [size]="boxSize() === 'small' ? 24 : 32"

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
@@ -34,7 +34,7 @@ $box_icon_appearance: colorFn.map-merged(
   }
 
   &.circle {
-    border-radius: rem.rem_calc(48);
+    border-radius: rem.rem_calc(50%);
   }
 
   @each $name, $color in $box_icon_appearance {

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
@@ -33,6 +33,10 @@ $box_icon_appearance: colorFn.map-merged(
     border-radius: var(--bmb-radius-m);
   }
 
+  &.circle {
+    border-radius: rem.rem_calc(48);
+  }
+
   @each $name, $color in $box_icon_appearance {
     &.#{$name} {
       background-color: $color;

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.scss
@@ -34,7 +34,7 @@ $box_icon_appearance: colorFn.map-merged(
   }
 
   &.circle {
-    border-radius: rem.rem_calc(50%);
+    border-radius: 50%;
   }
 
   @each $name, $color in $box_icon_appearance {

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.spec.ts
@@ -24,4 +24,14 @@ describe('BmbBoxIconComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should apply the circle box shape class', () => {
+    componentRef.setInput('boxShape', 'circle');
+    fixture.detectChanges();
+
+    const boxIcon = fixture.nativeElement.querySelector('.bmb_box-icon');
+
+    expect(boxIcon.classList).toContain('circle');
+  });
+
 });

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.component.ts
@@ -20,6 +20,7 @@ import { IBmbInteractiveIconAppearance } from '../bmb-interactive-icon/bmb-inter
 import { IBmbColor } from '../../types';
 
 export type IBmbBoxIconSize = 'regular' | 'small';
+export type IBmbBoxIconShape = 'square' | 'circle';
 
 @Component({
   selector: 'bmb-box-icon',
@@ -47,6 +48,7 @@ export class BmbBoxIconComponent {
     | IBmbColor
   >();
   boxSize = input<IBmbBoxIconSize>('small');
+  boxShape = input<IBmbBoxIconShape>('square');
 
   get colorName(): string {
     return `${this.boxColor() || 'transparent'}`;

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
@@ -39,16 +39,29 @@ ${getBasicExampleBlock('BmbBoxIconComponent', ON_BUTTON_CLICK.handleExample)}
     iconImageAlt: DBmbIconParamDesc.alt,
     isIconFilled: DBmbIconParamDesc.isIconFill,
     boxColor: getAppearanceParam('the box icon', colorList),
+    boxShape: {
+      control: 'select',
+      options: ['square', 'circle'],
+      description:
+        'Defines the box shape. Square keeps the radius associated with the box size and circle applies a 48px border radius.',
+    },
   },
   args: {
     iconName: 'face',
     boxColor: 'semantic-success',
+    boxShape: 'square',
   },
 } as Meta<typeof BmbBoxIconComponent>;
 
 type Story = StoryObj<BmbBoxIconComponent>;
 
 export const Default: Story = {};
+
+export const Circle: Story = {
+  args: {
+    boxShape: 'circle',
+  }
+};
 
 // export const AllColors = {
 //   render: () => ({

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
@@ -43,13 +43,15 @@ ${getBasicExampleBlock('BmbBoxIconComponent', ON_BUTTON_CLICK.handleExample)}
       control: 'select',
       options: ['square', 'circle'],
       description:
-        'Defines the box shape. Square keeps the radius associated with the box size and circle applies a 48px border radius.',
+        'Defines the box shape. Square keeps the radius associated with the box size and circle applies a 50% border radius.',
     },
+    boxSize: getAppearanceParam('the box size', ['small', 'regular'], 'small'),
   },
   args: {
     iconName: 'face',
     boxColor: 'semantic-success',
     boxShape: 'square',
+    boxSize: 'small',
   },
 } as Meta<typeof BmbBoxIconComponent>;
 
@@ -60,7 +62,8 @@ export const Default: Story = {};
 export const Circle: Story = {
   args: {
     boxShape: 'circle',
-  }
+    boxSize: 'small',
+  },
 };
 
 // export const AllColors = {

--- a/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-box-icon/bmb-box-icon.stories.ts
@@ -39,12 +39,12 @@ ${getBasicExampleBlock('BmbBoxIconComponent', ON_BUTTON_CLICK.handleExample)}
     iconImageAlt: DBmbIconParamDesc.alt,
     isIconFilled: DBmbIconParamDesc.isIconFill,
     boxColor: getAppearanceParam('the box icon', colorList),
-    boxShape: {
-      control: 'select',
-      options: ['square', 'circle'],
-      description:
-        'Defines the box shape. Square keeps the radius associated with the box size and circle applies a 50% border radius.',
-    },
+    boxShape: getAppearanceParam(
+      'the box shape',
+      ['square', 'circle'],
+      'square',
+      '<br/><br/>Square keeps the radius associated with the box size and circle applies a 50% border radius.',
+    ),
     boxSize: getAppearanceParam('the box size', ['small', 'regular'], 'small'),
   },
   args: {


### PR DESCRIPTION
…dius del icono

[DS01-3651](https://tecdemonterrey.atlassian.net/browse/DS01-3651) - Box icon: square.

## Changes proposed in this PR: 💻

- Agregar boxShape square y circle: para agregar border-radius a icono en BoxIcon

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

Default: square
<img width="1011" height="396" alt="image" src="https://github.com/user-attachments/assets/6386d869-06c1-4937-914a-99ec7251f4fb" />

Circle
<img width="1018" height="398" alt="image" src="https://github.com/user-attachments/assets/9e4ecdf1-8b51-46d6-acc7-b9ab0e5f2c55" />


## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit tests before submitting (`npm run test`).
- [ ] I ran the E2E tests before submitting (`npm run e2e`).
- [ ] My code resolved all of the task's acceptance criteria.


[DS01-3651]: https://tecdemonterrey.atlassian.net/browse/DS01-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ