### PR TITLE
Ds01 3641

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-tooltip/bmb-tooltip-base/bmb-tooltip-base.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-tooltip/bmb-tooltip-base/bmb-tooltip-base.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BmbTooltipBaseComponent } from './bmb-tooltip-base.component';
 
+import { By } from '@angular/platform-browser';
+
 describe('BmbTooltipBaseComponent', () => {
   let component: BmbTooltipBaseComponent;
   let fixture: ComponentFixture<BmbTooltipBaseComponent>;
@@ -48,38 +50,4 @@ describe('BmbTooltipBaseComponent', () => {
     expect(tooltip?.textContent).not.toContain('Initial text');
   });
 
-  it('should use Spanish hyphenation rules by default', () => {
-    const tooltipBase = fixture.debugElement.query(
-      By.directive(BmbTooltipBaseComponent),
-    ).componentInstance as BmbTooltipBaseComponent;
-
-    tooltipBase.showTooltip();
-
-    const tooltip = document.body.querySelector<HTMLDialogElement>(
-      '.bmb_tooltip-dialog',
-    );
-
-    expect(tooltip?.lang).toBe('es');
-
-    tooltipBase.hideTooltip();
-  });
-
-  it('should pass a configured language to the floating tooltip', () => {
-    fixture.componentRef.setInput('language', 'en');
-    fixture.detectChanges();
-
-    const tooltipBase = fixture.debugElement.query(
-      By.directive(BmbTooltipBaseComponent),
-    ).componentInstance as BmbTooltipBaseComponent;
-
-    tooltipBase.showTooltip();
-
-    const tooltip = document.body.querySelector<HTMLDialogElement>(
-      '.bmb_tooltip-dialog',
-    );
-
-    expect(tooltip?.lang).toBe('en');
-
-    tooltipBase.hideTooltip();
-  });
 });

--- a/projects/ds-ng/src/lib/components/bmb-tooltip/bmb-tooltip-base/bmb-tooltip-base.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-tooltip/bmb-tooltip-base/bmb-tooltip-base.component.spec.ts
@@ -2,8 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BmbTooltipBaseComponent } from './bmb-tooltip-base.component';
 
-import { By } from '@angular/platform-browser';
-
 describe('BmbTooltipBaseComponent', () => {
   let component: BmbTooltipBaseComponent;
   let fixture: ComponentFixture<BmbTooltipBaseComponent>;


### PR DESCRIPTION
[DS01-3641](https://tecdemonterrey.atlassian.net/browse/DS01-3641) - [GH-tec-design-system-ng-1200] bmb-tooltip hace mal la division de silabas en palabras compuestas

## Changes proposed in this PR: 💻

- Ajuste de test por variable language de input a computed, la cual se obtene por servicio

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

<img width="1437" height="174" alt="image" src="https://github.com/user-attachments/assets/0734d8ca-e9ae-4965-9510-aa5b2dccdc0c" />


<img width="1434" height="175" alt="image" src="https://github.com/user-attachments/assets/9e43c986-af0f-4d89-9c97-21ed1af8def0" />


Add screenshots of the result of your changes proposed.

## Checklist ✔️



Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit tests before submitting (`npm run test`).
- [ ] I ran the E2E tests before submitting (`npm run e2e`).
- [ ] My code resolved all of the task's acceptance criteria.


[DS01-3641]: https://tecdemonterrey.atlassian.net/browse/DS01-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ