### PR TITLE
feat(component / layout): Se agegró soporte para modo invertido

### DIFF
--- a/projects/ds-ng/src/assets/styles/components/_col-sys.scss
+++ b/projects/ds-ng/src/assets/styles/components/_col-sys.scss
@@ -148,6 +148,58 @@ $alignItemsOptions: (
   &-no-row-wrap {
     flex-wrap: nowrap;
   }
+
+  &-flow {
+    &-row {
+      flex-direction: row;
+    }
+
+    &-reverse {
+      flex-direction: row-reverse;
+      flex-wrap: wrap-reverse;
+    }
+
+    &-m {
+      @include mixins.media-query(1000, 'max') {
+        &-row {
+          flex-direction: row;
+        }
+
+        &-reverse {
+          flex-direction: row-reverse;
+          flex-wrap: wrap-reverse;
+        }
+      }
+    }
+
+    &-l {
+      @include mixins.media-query(1001, 'min') {
+        &-row {
+          flex-direction: row;
+        }
+
+        &-reverse {
+          flex-direction: row-reverse;
+          flex-wrap: wrap-reverse;
+        }
+      }
+    }
+
+    &-xl {
+      @include mixins.media-query(1400, 'min') {
+        &-row {
+          flex-direction: row;
+        }
+
+        &-reverse {
+          flex-direction: row-reverse;
+          flex-wrap: wrap-reverse;
+        }
+      }
+    }
+  }
+
+
 }
 
 @each $side in $namesOfSides {

--- a/projects/ds-ng/src/lib/directives/bmb-layout/bmb-layout.directive.ts
+++ b/projects/ds-ng/src/lib/directives/bmb-layout/bmb-layout.directive.ts
@@ -10,6 +10,12 @@ export type IJustifyOptions =
   | 'spaceBetween'
   | 'spaceEvenly';
 export type IAlignItemsOptions = 'center' | 'end' | 'start' | 'stretch';
+export type ILayoutFlow = 'row' | 'reverse';
+export interface ILayoutFlowResponsive {
+  m: ILayoutFlow;
+  l: ILayoutFlow;
+  xl: ILayoutFlow;
+}
 
 @Directive({
   selector: '[bmbLayout]',
@@ -23,6 +29,7 @@ export class BmbLayoutDirective {
   alignItems = input<IAlignItemsOptions>('start');
   isContainerQuery = input<boolean>();
   avoidRowWrap = input<boolean>(false);
+  flow = input<ILayoutFlow | ILayoutFlowResponsive>('row');
 
   @HostBinding('class') get elementClass(): string[] {
     const baseClassName: string = 'bmb_layout';
@@ -33,6 +40,14 @@ export class BmbLayoutDirective {
       `bmb_align-items-${this.alignItems()}`,
     ];
 
+    const flow = this.flow();
+    if (typeof flow === 'string') {
+      classes.push(`${baseClassName}-flow-${flow}`);
+    } else {
+      (Object.keys(flow) as (keyof ILayoutFlowResponsive)[]).forEach((device) => {
+        classes.push(`${baseClassName}-flow-${device}-${flow[device]}`);
+      });
+    }
     if (this.dynamicCols()) classes.push(`${baseClassName}-smart`);
     if (this.isContainerQuery()) classes.push(`${baseClassName}-container`);
     else classes.push(baseClassName);

--- a/projects/ds-ng/src/lib/directives/bmb-layout/bmb-layout.stories.ts
+++ b/projects/ds-ng/src/lib/directives/bmb-layout/bmb-layout.stories.ts
@@ -19,6 +19,7 @@ import {
 } from '../../utils/doc/utils';
 import { DBmbLayoutParamDesc } from '../../utils/doc/parameterDescriptions';
 import { BmbInteractiveIconComponent } from '../../components/bmb-interactive-icon/bmb-interactive-icon.component';
+import { str } from 'storybook/internal/docs-tools';
 
 const meta: Meta<BmbLayoutDirective> = {
   title: 'Foundations/Layouts/Layout',
@@ -121,6 +122,16 @@ ${RELEVANT_TITLE.configuration}
         type: { summary: 'boolean' },
       },
     },
+    flow: {
+      control: 'select',
+      options: ['row', 'reverse'],
+      description: 'Sets the flex-flow to the grid',
+      table: {
+        category: 'Properties',
+        defaultValue: { summary: 'row' },
+        type: { summary: 'ILayoutFlow | ILayoutFlowResponsive' }
+      }
+    },
     avoidRowWrap: {
       control: { type: 'boolean' },
       description: 'Prevents items from wrapping to the next row when true.',
@@ -138,6 +149,7 @@ ${RELEVANT_TITLE.configuration}
     justify: 'start',
     alignItems: 'start',
     avoidRowWrap: false,
+    flow: 'row',
   },
 };
 
@@ -151,24 +163,24 @@ export const Default = {
     props: args,
     template: `
       <section bmbLayout ${attributes(args)}>
-        <bmb-card bmbLayoutItem margin="none" [colSm]="2" [colLg]="3">
+        <bmb-card bmbLayoutItem margin="none" [colSm]="4" [colLg]="3">
           <bmb-card-content padding="m">
-            <span>Column</span>
+            <span>Column 1</span>
           </bmb-card-content>
         </bmb-card>
         <bmb-card bmbLayoutItem margin="none" [colSm]="2" [colLg]="3">
           <bmb-card-content padding="m">
-            <span>Column</span>
+            <span>Column 2</span>
           </bmb-card-content>
         </bmb-card>
         <bmb-card bmbLayoutItem margin="none" [colSm]="2" [colLg]="3">
           <bmb-card-content padding="m">
-            <span>Column</span>
+            <span>Column 3</span>
           </bmb-card-content>
         </bmb-card>
-        <bmb-card bmbLayoutItem margin="none" [colSm]="2" [colLg]="3">
+        <bmb-card bmbLayoutItem margin="none" [colSm]="4" [colLg]="3">
           <bmb-card-content padding="m">
-            <span>Column</span>
+            <span>Column 4</span>
           </bmb-card-content>
         </bmb-card>
       </section>


### PR DESCRIPTION
This pull request adds support for a new `flow` property to the `BmbLayoutDirective`, allowing developers to control the flex-direction and wrapping behavior of layouts, including responsive options for different breakpoints. The changes also update the Storybook stories to document and demonstrate this new feature.

**New layout flow support:**

* Added a `flow` input to `BmbLayoutDirective`, accepting either a string (`'row'` or `'reverse'`) or an object for responsive values (`{ m, l, xl }`), enabling flexible and responsive control of flex-direction and wrap.
* Updated the SCSS (`_col-sys.scss`) to provide new CSS classes for the `flow` options and their responsive variants, applying the correct flex-direction and wrap styles at each breakpoint.

**Storybook and documentation updates:**

* Added the `flow` property to Storybook controls and default args, improving documentation and making it easier to test the new feature interactively.
* Updated the default Storybook example to use the new `flow` property and clarified card labels for better demonstration.

**Other improvements:**

* Minor import cleanup in Storybook files.

## Changes proposed in this PR: 💻

-

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.

## Checklist ✔️

Please check all steps on the checklist

- [ ] My code matches all coding standars.
- [ ] I included the documentation files (.stories.ts).
- [ ] I ran the unit tests before submitting (`npm run test`).
- [ ] I ran the E2E tests before submitting (`npm run e2e`).
- [ ] My code resolved all of the task's acceptance criteria.
