### PR TITLE
fix(component / filter card): Se corrigió el bug de filter card donde…

### DIFF
--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.html
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.html
@@ -39,9 +39,7 @@
                         [text]="control.label"
                         [dismissible]="false"
                         [enableClick]="true"
-                        [isActive]="
-                          storedValues[control.name]?.checked ?? false
-                        "
+                        [isActive]="isTagSelected(control.name)"
                         (clickedTag)="controlChange(control, $event)"
                       />
                     }
@@ -97,7 +95,12 @@
         }
         @if (inLine()) {
           <footer class="bmb_filter_card-footer">
-            <button bmbButton appearance="secondary-outlined" type="reset">
+            <button
+              bmbButton
+              appearance="secondary-outlined"
+              type="button"
+              (click)="clearAllFilters()"
+            >
               {{ secondaryBtnLabel() }}
             </button>
             <button bmbButton (click)="handleSubmit()" type="submit">
@@ -116,7 +119,6 @@
       type="button"
       class="bmb_filter_card-button"
       (click)="openModalComponent()"
-      type="button"
     >
       <bmb-icon [icon]="icon()" alt="Filter icon" />
     </button>

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.spec.ts
@@ -213,7 +213,7 @@ describe('BmbFilterCardComponent', () => {
       expect(component.isSectionVisible(deptosSection)).toBeFalse();
     });
 
-    it('should reset visibility when onReset is called', () => {
+    it('should reset visibility when clearAllFilters is called', () => {
       const fixture = TestBed.createComponent(BmbFilterCardComponent);
       const component = fixture.componentInstance;
       fixture.componentRef.setInput('controlTypes', baseControlTypes);
@@ -226,7 +226,7 @@ describe('BmbFilterCardComponent', () => {
       );
       fixture.detectChanges();
 
-      component.onReset();
+      component.clearAllFilters();
       fixture.detectChanges();
 
       expect(component.isControlVisible('tipoEval')).toBeTrue();
@@ -588,6 +588,29 @@ describe('BmbFilterCardComponent', () => {
       component.controlChange({ name: 'tag1', type: 'tag' }, null);
       expect(component.filterForm.get('tag1')?.value).toBeTrue();
       expect(component.storedValues['tag1'].checked).toBeTrue();
+      expect(component.isTagSelected('tag1')).toBeTrue();
+    });
+
+    it('should clear tag selection with clearAllFilters', () => {
+      const fixture = TestBed.createComponent(BmbFilterCardComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('controlTypes', [
+        {
+          title: 'Tags',
+          control: [
+            { name: 'tag-1', type: 'tag', label: 'Tag 1', checked: true },
+            { name: 'tag-2', type: 'tag', label: 'Tag 2', checked: true },
+          ],
+        },
+      ]);
+      fixture.detectChanges();
+
+      expect(component.isTagSelected('tag-1')).toBeTrue();
+      component.clearAllFilters();
+
+      expect(component.isTagSelected('tag-1')).toBeFalse();
+      expect(component.isTagSelected('tag-2')).toBeFalse();
+      expect(component.storedValues['tag-1'].checked).toBeFalse();
     });
 
     it('should handle multiple radial inputs with the same name in ngOnInit', () => {
@@ -655,13 +678,13 @@ describe('BmbFilterCardComponent', () => {
       expect(component.filterForm.get('chk')).toBeNull();
     });
 
-    it('should explicitly emit reset event on onReset', () => {
+    it('should explicitly emit reset event on clearAllFilters', () => {
       const fixture = TestBed.createComponent(BmbFilterCardComponent);
       const component = fixture.componentInstance;
       const emitSpy = spyOn(component.resetFilters, 'emit');
       fixture.detectChanges();
 
-      component.onReset();
+      component.clearAllFilters();
       expect(emitSpy).toHaveBeenCalled();
     });
   });

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.component.ts
@@ -111,27 +111,30 @@ export class BmbFilterCardComponent implements OnInit {
   @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
 
   constructor(private modalService: BmbNativeModalService) {
-    effect(() => {
-      const visMap = this.visibleControlIds();
-      if (visMap) {
-        visMap.forEach((visible, name) => {
-          if (!visible) this.clearControl(name);
-        });
-      }
+    effect(
+      () => {
+        const visMap = this.visibleControlIds();
+        if (visMap) {
+          visMap.forEach((visible, name) => {
+            if (!visible) this.clearControl(name);
+          });
+        }
 
-      this.dynamicOptionsMap().forEach((options, name) => {
-        const current = this.filterForm.get(name)?.value;
-        if (!current || (Array.isArray(current) && current.length === 0))
-          return;
-        const validValues = options.map((o) =>
-          typeof o === 'string' ? o : o.value,
-        );
-        const isValid = Array.isArray(current)
-          ? current.every((v: string) => validValues.includes(v))
-          : validValues.includes(current);
-        if (!isValid) this.clearControl(name);
-      });
-    });
+        this.dynamicOptionsMap().forEach((options, name) => {
+          const current = this.filterForm.get(name)?.value;
+          if (!current || (Array.isArray(current) && current.length === 0))
+            return;
+          const validValues = options.map((o) =>
+            typeof o === 'string' ? o : o.value,
+          );
+          const isValid = Array.isArray(current)
+            ? current.every((v: string) => validValues.includes(v))
+            : validValues.includes(current);
+          if (!isValid) this.clearControl(name);
+        });
+      },
+      { allowSignalWrites: true },
+    );
   }
 
   ngOnInit(): void {
@@ -217,13 +220,13 @@ export class BmbFilterCardComponent implements OnInit {
       actions: [
         {
           label: this.primaryBtnLabel(),
-          action: this.handleSubmit.bind(this),
+          action: () => this.handleSubmit(),
           appearance: 'primary',
           buttonName: this.primaryBtnLabel(),
         },
         {
           label: this.secondaryBtnLabel(),
-          action: this.onReset.bind(this),
+          action: () => this.clearAllFilters(),
           appearance: 'secondary-outlined',
           buttonName: this.secondaryBtnLabel(),
         },
@@ -321,7 +324,7 @@ export class BmbFilterCardComponent implements OnInit {
     this.applyFilters.emit(formData);
   }
 
-  onReset() {
+  clearAllFilters() {
     this.filterForm.reset();
     this.filterValues.set({});
     Object.keys(this.storedValues).forEach((name) => {
@@ -342,6 +345,10 @@ export class BmbFilterCardComponent implements OnInit {
       };
     });
     this.resetFilters.emit();
+  }
+
+  isTagSelected(name: string): boolean {
+    return this.filterValues()[name] === true;
   }
 
   private ruleMatches(

--- a/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.stories.ts
+++ b/projects/ds-ng/src/lib/components/bmb-filter-card/bmb-filter-card.stories.ts
@@ -31,7 +31,8 @@ export default {
         exclude: [
           'getFormControl',
           'onControlChange',
-          'onReset',
+          'clearAllFilters',
+          'isTagSelected',
           'onSubmit',
           'onValueChange',
           'openModalComponent',

--- a/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.spec.ts
+++ b/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.spec.ts
@@ -10,6 +10,7 @@ describe('BmbTagComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BmbTagComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
   });
 
   it('should create the component', () => {
@@ -26,7 +27,6 @@ describe('BmbTagComponent', () => {
   });
 
   it('should display text inside the badge', () => {
-    componentRef = fixture.componentRef;
     componentRef.setInput('text', 'Sample Text');
     fixture.detectChanges();
 
@@ -34,5 +34,34 @@ describe('BmbTagComponent', () => {
     const textElement = element.querySelector('.bmb_tag span');
 
     expect(textElement?.textContent).toContain('Sample Text');
+  });
+
+  it('should respect isActive when enableClick is true', () => {
+    componentRef.setInput('text', 'Escuela');
+    componentRef.setInput('enableClick', true);
+    componentRef.setInput('isActive', true);
+    fixture.detectChanges();
+
+    const button: HTMLElement | null =
+      fixture.nativeElement.querySelector('button');
+    expect(button?.classList).toContain('bmb_tag-active');
+
+    componentRef.setInput('isActive', false);
+    fixture.detectChanges();
+
+    expect(button?.classList).not.toContain('bmb_tag-active');
+  });
+
+  it('should emit clickedTag without toggling local active state', () => {
+    componentRef.setInput('text', 'Depto');
+    componentRef.setInput('enableClick', true);
+    componentRef.setInput('isActive', true);
+    fixture.detectChanges();
+
+    const emitSpy = spyOn(component.clickedTag, 'emit');
+    component.clickTag('Depto');
+
+    expect(emitSpy).toHaveBeenCalledWith('Depto');
+    expect(component.getClasses()).toContain('bmb_tag-active');
   });
 });

--- a/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.ts
+++ b/projects/ds-ng/src/lib/components/bmb-tags/bmb-tags.component.ts
@@ -59,8 +59,6 @@ export class BmbTagComponent implements AfterViewInit {
   closedTag = output<string>();
   clickedTag = output<string>();
 
-  private active = false;
-
   groupedTags = [];
 
   constructor(
@@ -91,10 +89,8 @@ export class BmbTagComponent implements AfterViewInit {
       `bmb_tag-${this.appearance()}`,
     ];
 
-    const active = this.enableClick() ? this.active : this.isActive();
-
     if (this.dismissible() || this.enableClick()) {
-      if (active) {
+      if (this.isActive()) {
         classes.push('bmb_tag-active');
       }
 
@@ -113,10 +109,6 @@ export class BmbTagComponent implements AfterViewInit {
   }
 
   clickTag(text: string) {
-    if (this.enableClick() && !this.isDisabled()) {
-      this.active = !this.active;
-    }
-
     this.clickedTag.emit(text);
   }
 }


### PR DESCRIPTION
… no se reseteaban los filtros y había inconsistencias en el estado de los elementos seleccionados

[DS01-3662](https://tecdemonterrey.atlassian.net/browse/DS01-3662) -3662

## Changes proposed in this PR: 💻

- Se corrigió el bug de filter card donde no se reseteaban los filtros y había inconsistencias en el estado de los elementos seleccionados

## Chromatic URL

[Chromatic](https://www.chromatic.com/build?appId=65c3b4d1f966b98bb1f4e774&number=)

## Visuals 🎴

Add screenshots of the result of your changes proposed.
<img width="483" height="431" alt="image" src="https://github.com/user-attachments/assets/9606a57e-a861-4b83-ab51-bc5d693ffc67" />
<img width="473" height="445" alt="image" src="https://github.com/user-attachments/assets/dea90b4e-e108-4359-a84e-e198dca431b1" />


## Checklist ✔️

Please check all steps on the checklist

- [✔️ ] My code matches all coding standars.
- [✔️ ] I included the documentation files (.stories.ts).
- [✔️ ] I ran the unit tests before submitting (`npm run test`).
- [✔️ ] I ran the E2E tests before submitting (`npm run e2e`).
- [✔️ ] My code resolved all of the task's acceptance criteria.


[DS01-3662]: https://tecdemonterrey.atlassian.net/browse/DS01-3662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ